### PR TITLE
Simple database logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "TapVote =======",
   "main": "index.js",
   "dependencies": {
-    "node-static": ">=0.7.1"
+    "node-static": ">=0.7.1",
+    "cloned": ">=0.0.1",
+    "async": ">=0.2.6",
+    "pg": ">=2.6"   
    },
   "devDependencies": {},
   "scripts": {

--- a/server/database.js
+++ b/server/database.js
@@ -1,0 +1,41 @@
+var pg = require("pg"); // PostgreSQL client library
+
+// this should be used anytime we need to connect to the DB
+var CONNSTRING = "postgres://postgres:wearetapvote@localhost/tapvotetest";
+
+
+var recordVote = function(voteData, callback) {
+    // voteData = {'vote':'a'}
+    runQuery("INSERT INTO test(vote) VALUES($1)", [voteData['vote']], callback)
+}
+
+// local scope, don't export
+var runQuery = function(queryString, values, callback) {
+    pg.connect(CONNSTRING, function(err, client, done) {
+        if (err) {
+            err["friendlyName"] = "Database connection error";
+            console.log("Database connection error!", err)
+            callback(err);
+            return;
+        }
+
+        else {
+            client.query(queryString, values, function(err, results) {
+                done(); // called to release the connection client into the pool
+                if (err) {
+                    err["friendlyName"] = "Query error";
+                    console.log("Query error!", err)
+                    callback(err);
+                    return;
+                }
+                else {
+                    callback(err, results);
+                    return;
+                }
+            });
+        }
+    });
+}
+
+
+exports.recordVote = recordVote;

--- a/server/requestHandlers.js
+++ b/server/requestHandlers.js
@@ -1,6 +1,11 @@
 var exec = require("child_process").exec;
+var pg = require("pg");  // PostgreSQL client library
+
+// this should be used anytime we need to connect to the DB
+var CONNSTRING = "postgres://postgres:wearetapvote@localhost/tapvotetest";
+
 function index(response, postData) {
-    console.log("Request handler 'index' was called.");
+    console.log("[INFO] Request handler 'index' was called.");
     exec("ls -lah", function (error, stdout, stderr) {
         response.writeHead(200, {"Content-Type": "text/plain"});
         response.write(stdout);
@@ -9,20 +14,41 @@ function index(response, postData) {
 }
 
 function vote(response, postData) {
-    console.log("Request handler 'vote' was called.");
+    //Test this endpoint with curl -d '{"vote": "a"}' -H "Content-Type: application/json" http://localhost:8000/vote
+    console.log("[INFO] Request handler 'vote' was called.");
+
     try {
         data = JSON.parse(postData);
-        response.writeHead(200, {"Content-Type": "text/plain"});
-        //Echo bach the postData for now
-        response.write(postData);
-        //Test with curl -d '{"vote": "a"}' -H "Content-Type: application/json" http://localhost:8000/vote
-        console.log("Incoming vote: " + data['vote']);
-        response.end();
     } catch (err) {
         response.writeHead(400, {"Content-Type": "text/plain"});
         response.write("400 Bad Request");
         response.end();
     }
+    response.writeHead(200, {"Content-Type": "text/plain"});
+
+    //Echo back the postData for now
+    response.write(postData);
+
+    console.log("[INFO] Incoming vote: " + data['vote']);
+
+    // pg.connect uses the pg library's built-in connection pool (client refers to the current connection)
+    pg.connect(CONNSTRING, function(err, client, done) {
+        if(err) {
+            return console.log("[ERROR] Couldn't fetch a client from the Postgres connection pool.", err);
+        };
+
+        client.query("INSERT INTO test(vote) VALUES($1)", [data['vote']], function(err, results) {
+            done(); // called to release the client back into the connection pool
+            
+            if(err) {
+                return console.log("[ERROR] Error running query.", err);
+            }
+
+            console.log("[INFO] Logged vote " + data['vote'] + " to database.");
+        });
+    });
+    
+    response.end();
 }
 
 exports.index = index;


### PR DESCRIPTION
Initial stab at storing votes in a Postgres database (take a look at the main wiki page for some info on setting up a dev database). This resolves #12.

This adds some node modules to `package.json`, so make sure you run `sudo npm install` after pull in the changes.

I also took a stab at some error handling integration. It's still pretty primitive, but at least every error returns _some_ sort of HTTP error code (even if it's only `400 Bad Request`...).

At the point, the only way to see the votes currently in the database is to connect to it using `psql` and directly query the table:

```
$ sudo -u postgres psql tapvotetest
# SELECT * FROM test;
```

The next step will be to make a JSON controller/API endpoint that returns all the votes currently in the database.
