### PR TITLE
silly error: passing the unparsed post data to the database handler

### DIFF
--- a/server/requestHandlers.js
+++ b/server/requestHandlers.js
@@ -26,7 +26,7 @@ function vote(response, postData) {
 
     console.log("[INFO] Incoming vote: " + data['vote']);
     // TODO update with actual data (timestamp, uid, etc?)
-    database.recordVote(postData, function(err, results) {
+    database.recordVote(data, function(err, results) {
         if (err) {
             err["httpStatus"] = 500;
             err["httpResponse"] = "500 Internal Server Error";


### PR DESCRIPTION
I was passing the postData string to the database instead of passing the object that we get from JSON.parse(). It was causing requests to be logged as empty strings.
