### PR TITLE
Response endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/*
 deploy.cgi
 .idea/
 .project
+*~

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 
 var express = require('express');
 var vote = require('./routes/vote');
+var responses = require('./routes/responses');
 var http = require('http');
 var path = require('path');
 
@@ -33,6 +34,7 @@ if ('development' == app.get('env')) {
 }
 
 app.post('/vote', vote.vote);
+app.get('/responses', responses.responses);
 
 http.createServer(app).listen(app.get('port'), function(){
   console.log('Express server listening on port ' + app.get('port'));

--- a/modules/database.js
+++ b/modules/database.js
@@ -32,7 +32,8 @@ var createSurvey = function(surveyData, callback) {
 }
 
 exports.recordVote = recordVote;
-
+exports.getResponses = getResponses;
+exports.createSurvey = createSurvey;
 
 // ==================================================================================================
 // local scope, don't export

--- a/modules/httpresponses.js
+++ b/modules/httpresponses.js
@@ -2,19 +2,23 @@ function errorResponse(err, response) {
     message = {'status':'error', 'message':err['friendlyName']};
 
     response.writeHead(err["httpStatus"], {"Content-Type": "application/json"});
-    response.write(err["httpResponse"] + "\n");
+    //response.write(err["httpResponse"] + "\n");
     response.write(JSON.stringify(message) + "\n");
     response.end();
 
     console.log("[ERROR]", err)
 }
 
-function successResponse(response) {
-    message = {'status':'success'};
+function successResponse(response, results) {
+    if (!results) {
+        results = {'status':'success'};
+    }
+    
+    message = JSON.stringify(results) + "\n";
 
     response.writeHead(200, {"Content-Type": "application/json"});
-    response.write("200 OK" + "\n");
-    response.write(JSON.stringify(message) + "\n");
+    //response.write("200 OK" + "\n");
+    response.write(message);
     response.end();
 }
 

--- a/routes/responses.js
+++ b/routes/responses.js
@@ -2,7 +2,7 @@ var database = require("../modules/database");
 var httpresponses = require("../modules/httpresponses");
 
 function responses(req, response) {
-    //Test this endpoint with curl -d '{"surveyId": "xxx" }' -H "Content-Type: application/json" http://localhost:8000/responses
+    //Test this endpoint with curl http://localhost:8000/responses?surveyId=0
     console.log("[INFO] Request handler 'responses' was called.");
     data = req.query;
     if (!data['surveyId']) { //this can happen if the content-type isn't set correctly when you send raw JSON

--- a/routes/responses.js
+++ b/routes/responses.js
@@ -1,0 +1,38 @@
+var database = require("../modules/database");
+var httpresponses = require("../modules/httpresponses");
+
+function responses(req, response) {
+    //Test this endpoint with curl -d '{"surveyId": "xxx" }' -H "Content-Type: application/json" http://localhost:8000/responses
+    console.log("[INFO] Request handler 'responses' was called.");
+    data = req.query;
+    if (!data['surveyId']) { //this can happen if the content-type isn't set correctly when you send raw JSON
+        err = new Error()
+        err["httpStatus"] = 400;
+        err["httpResponse"] = "400 Bad Request";
+        err["friendlyName"] = "JSON parse error";
+        httpresponses.errorResponse(err, response);
+        return;
+    }
+
+    console.log("[INFO] Incoming request for responses for: " + data['surveyId']);
+    // TODO update with actual data (timestamp, uid, etc?)
+    database.getResponses(data, function(err, results) {
+        if (err) {
+            err["httpStatus"] = 500;
+            err["httpResponse"] = "500 Internal Server Error";
+            if (!err["friendlyName"]) {
+                err["friendlyName"] = "Error recording vote";
+            }
+            httpresponses.errorResponse(err, response);
+            return;
+        }
+        else {
+            console.log("[INFO] Returning survey data");
+            httpresponses.successResponse(response, results);
+            return;
+        }
+    });
+}
+
+exports.responses = responses;
+


### PR DESCRIPTION
Closes #28.

Note: Because GETs don't have bodies, we're using query string parameters instead (which was a dead simple one-line change in express)
