### PR TITLE
Fix camel-cased column names

### DIFF
--- a/modules/database.js
+++ b/modules/database.js
@@ -65,12 +65,12 @@ var getSurveyResults = function (surveyData, callback) {
     var surveyId = surveyData['surveyId'];
     logger.info("Getting survey results from database for surveyId", surveyId);
 
-    var queryString = "SELECT v.answerId, COUNT(*) \
+    var queryString = 'SELECT v."answerId", COUNT(*) \
                        FROM survey AS s \
-                           INNER JOIN question AS q ON s.id = q.surveyId AND s.id = $1 \
-                           INNER JOIN vote AS v ON q.id = v.questionId \
-                       GROUP BY v.answerId \
-                       ORDER BY v.answerId";
+                           INNER JOIN question AS q ON s.id = q."surveyId" AND s.id = $1 \
+                           INNER JOIN vote AS v ON q.id = v."questionId" \
+                       GROUP BY v."answerId" \
+                       ORDER BY v."answerId"';
 
     runQuery(queryString, [surveyId])
     .then(function (results) {

--- a/modules/database.js
+++ b/modules/database.js
@@ -6,7 +6,7 @@ var CONNSTRING = "postgres://postgres:wearetapvote@localhost/tapvotetest";
 
 var recordVote = function (voteData, callback) {
     // voteData = {'answerId':5, 'questionId':5}
-    runQuery("INSERT INTO vote(answerId, questionId) VALUES($1, $2)", [voteData['answerId'], voteData['questionId']])
+    runQuery('INSERT INTO vote("answerId", "questionId") VALUES($1, $2)', [voteData['answerId'], voteData['questionId']])
     .then(function (results) {
         logger.info("Recorded vote in database.");
         callback(null, results);
@@ -26,11 +26,11 @@ var getSurveyInfo = function(surveyData, callback) {
     // See http://stackoverflow.com/a/19439766/1576908 for more info on what is going on here
 
     // get questions for surveyId
-    runQuery("SELECT * FROM question WHERE surveyId=$1", [surveyId])
+    runQuery('SELECT * FROM question WHERE "surveyId"=$1', [surveyId])
     .then(function (results) {
         var questions = results.rows;
         return Q.all(questions.map(function (question) { // map each question into a function to get its answers
-            return runQuery("SELECT * FROM answer WHERE questionId=$1", [question.id])
+            return runQuery('SELECT * FROM answer WHERE "questionId"=$1', [question.id])
             .then(function (answers) {
                 question.answers = answers.rows; // annotate each question w/ the list of answers
                 return question;
@@ -41,7 +41,7 @@ var getSurveyInfo = function(surveyData, callback) {
     .then(function (results) {
         // results is a list of questions each annotated with a list of answers.
         // Still need to do a query to get survey info from DB (mainly the survey title).
-        return runQuery("SELECT * FROM survey WHERE id=$1", [surveyId])
+        return runQuery('SELECT * FROM survey WHERE id=$1', [surveyId])
         .then(function (survey) {
             var title = survey.rows[0].title;
             return {title: title, questions: results};
@@ -97,7 +97,7 @@ var createSurvey = function (surveyData, callback) {
     var password = surveyData['password'];
 
     logger.info("Inserting new survey into database...");
-    runQuery("INSERT INTO survey(title, password) VALUES($1, $2) RETURNING *", [title, password])
+    runQuery('INSERT INTO survey(title, password) VALUES($1, $2) RETURNING *', [title, password])
     .then(function (result) {
         // insert the new survey (return the survey ID to use in inserting questions)
         logger.info("Inserted survey. New survey ID is", result.rows[0].id);
@@ -110,14 +110,14 @@ var createSurvey = function (surveyData, callback) {
             var question = questions[q];
             var value = question['question'];
             var answers = question['answers'];
-            runQuery("INSERT INTO question(surveyId, value) VALUES($1, $2) RETURNING *", [sid, value])
+            runQuery('INSERT INTO question("surveyId", value) VALUES($1, $2) RETURNING *', [sid, value])
 
             .then(function (result) {
                 // insert all the answers for this question
                 var qid = result.rows[0].id;
                 for (var a=0; a<answers.length; a++) {
                     var answer = answers[a];
-                    runQuery("INSERT INTO answer(questionId, value) VALUES($1, $2)", [qid, answer])
+                    runQuery('INSERT INTO answer("questionId", value) VALUES($1, $2)', [qid, answer])
                 }
             });
         }

--- a/modules/database.js
+++ b/modules/database.js
@@ -6,7 +6,7 @@ var CONNSTRING = "postgres://postgres:wearetapvote@localhost/tapvotetest";
 
 var recordVote = function (voteData, callback) {
     // voteData = {'answerId':5, 'questionId':5}
-    runQuery("INSERT INTO vote(answerid, questionid) VALUES($1, $2)", [voteData['answerId'], voteData['questionId']])
+    runQuery("INSERT INTO vote(answerId, questionId) VALUES($1, $2)", [voteData['answerId'], voteData['questionId']])
     .then(function (results) {
         logger.info("Recorded vote in database.");
         callback(null, results);
@@ -26,11 +26,11 @@ var getSurveyInfo = function(surveyData, callback) {
     // See http://stackoverflow.com/a/19439766/1576908 for more info on what is going on here
 
     // get questions for surveyId
-    runQuery("SELECT * FROM question WHERE surveyid=$1", [surveyId])
+    runQuery("SELECT * FROM question WHERE surveyId=$1", [surveyId])
     .then(function (results) {
         var questions = results.rows;
         return Q.all(questions.map(function (question) { // map each question into a function to get its answers
-            return runQuery("SELECT * FROM answer WHERE questionid=$1", [question.id])
+            return runQuery("SELECT * FROM answer WHERE questionId=$1", [question.id])
             .then(function (answers) {
                 question.answers = answers.rows; // annotate each question w/ the list of answers
                 return question;
@@ -76,7 +76,7 @@ var getSurveyResults = function (surveyData, callback) {
     .then(function (results) {
         var ret = {};
         for (var r=0; r<results.rowCount; r++) {
-            var answerId = results.rows[r].answerid;
+            var answerId = results.rows[r].answerId;
             ret[answerId] = results.rows[r].count;
         }
         logger.info("Got survey results from database for surveyId", surveyId);
@@ -110,14 +110,14 @@ var createSurvey = function (surveyData, callback) {
             var question = questions[q];
             var value = question['question'];
             var answers = question['answers'];
-            runQuery("INSERT INTO question(surveyid, value) VALUES($1, $2) RETURNING *", [sid, value])
+            runQuery("INSERT INTO question(surveyId, value) VALUES($1, $2) RETURNING *", [sid, value])
 
             .then(function (result) {
                 // insert all the answers for this question
                 var qid = result.rows[0].id;
                 for (var a=0; a<answers.length; a++) {
                     var answer = answers[a];
-                    runQuery("INSERT INTO answer(questionid, value) VALUES($1, $2)", [qid, answer])
+                    runQuery("INSERT INTO answer(questionId, value) VALUES($1, $2)", [qid, answer])
                 }
             });
         }

--- a/routes/createSurvey.js
+++ b/routes/createSurvey.js
@@ -3,7 +3,7 @@ var httpresponses = require("../modules/httpresponses");
 var endpoint = require("../modules/endpoint");
 
 //Test this endpoint with
-//curl -d '{ "title":"\"Because clickers are SO 1999.\"", "questions": [{"question": "Which is best?", "answers": ["Puppies", "Cheese", "Joss Whedon", "Naps"]}],"password":"supersecretpassword" }' -H "Content-Type: application/json" http://localhost:8000/createSurvey
+//curl -d '{ "title":"Because clickers are SO 1999.", "questions": [{"question": "Which is best?", "answers": ["Puppies", "Cheese", "Joss Whedon", "Naps"]}],"password":"supersecretpassword" }' -H "Content-Type: application/json" http://localhost:8000/createSurvey
 
 function createSurvey(){
     var apiOptions = {};

--- a/routes/createSurvey.js
+++ b/routes/createSurvey.js
@@ -3,7 +3,7 @@ var httpresponses = require("../modules/httpresponses");
 var endpoint = require("../modules/endpoint");
 
 //Test this endpoint with
-//curl -d '{ "title":"Because clickers are SO 1999.", "questions": [{"question": "Which is best?", "answers": ["Puppies", "Cheese", "Joss Whedon", "Naps"]}],"password":"supersecretpassword" }' -H "Content-Type: application/json" http://localhost:8000/createSurvey
+//curl -d '{ "title":"\"Because clickers are SO 1999.\"", "questions": [{"question": "Which is best?", "answers": ["Puppies", "Cheese", "Joss Whedon", "Naps"]}],"password":"supersecretpassword" }' -H "Content-Type: application/json" http://localhost:8000/createSurvey
 
 function createSurvey(){
     var apiOptions = {};

--- a/routes/vote.js
+++ b/routes/vote.js
@@ -2,7 +2,8 @@ var database = require("../modules/database");
 var httpresponses = require("../modules/httpresponses");
 var endpoint = require("../modules/endpoint");
 
-//Test this endpoint with curl -d '{"answerId":5, "questionId":5}' -H "Content-Type: application/json" http://localhost:8000/vote
+// Test this endpoint with
+// curl -d '{"answerId":5, "questionId":5}' -H "Content-Type: application/json" http://localhost:8000/vote
 
 function vote(){
     var apiOptions = {};


### PR DESCRIPTION
Fixes #54.

**After merging this request, you will have to drop and recreate the database.**

To drop it:
`$ sudo -u postgres psql postgres`
`# drop database tapvotetest;`
`# create database tapvotetest;`
`<Alt-D>` to quit psql.
`$ sudo -u postgres psql tapvotetest`

Then paste in the schema from the wiki (https://github.com/LutherSrProject/TapVote/wiki).

Basically, the SQL standard ignores case in table and column names unless the name is in double quotes. Our spec uses things like `surveyId`, `answerId`, etc. However, when running queries against the database, results are returned in lowercase (because Postgres by default doesn't maintain any case info).

To fix, I changed the schema to put camel-cased table names in double quotes. This also required changing all the query code.
