### PR TITLE
Add a schema migration system

### DIFF
--- a/database.json
+++ b/database.json
@@ -1,0 +1,1 @@
+{ "dev": "postgres://postgres:wearetapvote@localhost/tapvotetest" }

--- a/migrations/20131029192647-version1.js
+++ b/migrations/20131029192647-version1.js
@@ -1,0 +1,33 @@
+var dbm = require('db-migrate');
+var type = dbm.dataType;
+
+exports.up = function(db, callback) {
+    db.runSql( 'CREATE TABLE survey ( \
+                    id           serial    PRIMARY KEY, \
+                    title        text, \
+                    password     text \
+                ); \
+\
+                CREATE TABLE question ( \
+                    id           serial    PRIMARY KEY,\
+                    "surveyId"   integer   REFERENCES survey(id),\
+                    value        text\
+                );\
+\
+                CREATE TABLE answer (\
+                    id           serial    PRIMARY KEY,\
+                    "questionId" integer   REFERENCES question(id) ,\
+                    value text\
+                );\
+\
+                CREATE TABLE vote (\
+                    id           serial,\
+                    "questionId" integer   REFERENCES question(id),\
+                    "answerId"   integer   REFERENCES answer(id)\
+                );\
+           ', callback);
+};
+
+exports.down = function(db, callback) {
+
+};

--- a/migrations/20131029192647-version1.js
+++ b/migrations/20131029192647-version1.js
@@ -25,9 +25,14 @@ exports.up = function(db, callback) {
                     "questionId" integer   REFERENCES question(id),\
                     "answerId"   integer   REFERENCES answer(id)\
                 );\
-           ', callback);
+           '
+     , callback);
 };
 
 exports.down = function(db, callback) {
-
+    db.runSql('DROP TABLE survey CASCADE;\
+              DROP TABLE question CASCADE;\
+              DROP TABLE answer CASCADE;\
+              DROP TABLE vote CASCADE;'
+    , callback);
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "async": ">=0.2.6",
     "pg": ">=2.6",
     "winston": ">=0.7.2",
-    "q": ">=0.9.7"
+    "q": ">=0.9.7",
+    "db-migrate": ">=0.6.2"
    },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This adds the ability to migrate schemas.

You will need to run `npm install` to get the library (node-db-migrate).

For this time only, to drop the database schema and then use the migration schema to re-create it, run the following commands from the repository root:

`$ node_modules/.bin/db-migrate down`
`$ node_modules/.bin/db-migrate up`

In the future, to apply any new schema migrations that I've checked in, you'll simply have to run:
`$ node_modules/.bin/db-migrate up`

I'm working on a way of automatically applying the latest schema, but I'm not there yet. This will also eventually allow an easy way for me to automatically insert some test data.
