### PR TITLE
add and remove questions database methods

### DIFF
--- a/migrations/20131031181640-version2.js
+++ b/migrations/20131031181640-version2.js
@@ -33,10 +33,14 @@ exports.up = function(db, callback) {
 };
 
 exports.down = function(db, callback) {
-    var queryString = "DELETE FROM vote WHERE \"questionId\"=1;\
-                       DELETE FROM answer WHERE \"questionId\"=1;\
-                       DELETE FROM question WHERE id=1;\
-                       DELETE FROM survey WHERE id=1;\
+    var queryString = "DELETE FROM vote WHERE \"questionId\">0;\
+                       DELETE FROM answer WHERE \"questionId\">0;\
+                       DELETE FROM question WHERE \"surveyId\">0;\
+                       DELETE FROM survey WHERE id>0;\
+                       ALTER SEQUENCE vote_id_seq RESTART WITH 1;\
+                       ALTER SEQUENCE answer_id_seq RESTART WITH 1;\
+                       ALTER SEQUENCE question_id_seq RESTART WITH 1;\
+                       ALTER SEQUENCE survey_id_seq RESTART WITH 1;\
                       ";
     db.runSql(queryString, callback);
 };

--- a/migrations/20131119155051-version3.js
+++ b/migrations/20131119155051-version3.js
@@ -16,6 +16,18 @@ exports.up = function(db, callback) {
         "                 ADD CONSTRAINT \"answer_questionId_fkey\"" +
         "                     FOREIGN KEY (\"questionId\")" +
         "                     REFERENCES question(id)" +
+        "                     ON DELETE CASCADE;" +
+        "" +
+        "              ALTER TABLE vote" +
+        "                 DROP CONSTRAINT \"vote_answerId_fkey\"," +
+        "                 DROP CONSTRAINT \"vote_questionId_fkey\"," +
+        "                 ADD CONSTRAINT \"vote_questionId_fkey\"" +
+        "                     FOREIGN KEY (\"questionId\")" +
+        "                     REFERENCES question(id)" +
+        "                     ON DELETE CASCADE," +
+        "                 ADD CONSTRAINT \"vote_answerId_fkey\"" +
+        "                     FOREIGN KEY (\"answerId\")" +
+        "                     REFERENCES answer(id)" +
         "                     ON DELETE CASCADE;";
 
     db.runSql(queryString, callback);
@@ -32,7 +44,17 @@ exports.down = function(db, callback) {
         "                 DROP CONSTRAINT \"answer_questionId_fkey\"," +
         "                 ADD CONSTRAINT  \"answer_questionId_fkey\"" +
         "                     FOREIGN KEY (\"questionId\")" +
-        "                     REFERENCES question(id);";
+        "                     REFERENCES question(id);" +
+        "" +
+        "              ALTER TABLE vote" +
+        "                 DROP CONSTRAINT \"vote_answerId_fkey\"," +
+        "                 DROP CONSTRAINT \"vote_questionId_fkey\"," +
+        "                 ADD CONSTRAINT \"vote_questionId_fkey\"" +
+        "                     FOREIGN KEY (\"questionId\")" +
+        "                     REFERENCES question(id)," +
+        "                 ADD CONSTRAINT \"vote_answerId_fkey\"" +
+        "                     FOREIGN KEY (\"answerId\")" +
+        "                     REFERENCES answer(id);";
 
     db.runSql(queryString, callback);
 };

--- a/migrations/20131119155051-version3.js
+++ b/migrations/20131119155051-version3.js
@@ -1,0 +1,38 @@
+var dbm = require('db-migrate');
+var type = dbm.dataType;
+
+
+// add on delete cascade
+exports.up = function(db, callback) {
+    var queryString = "ALTER TABLE question" +
+        "                 DROP CONSTRAINT \"question_surveyId_fkey\"," +
+        "                 ADD CONSTRAINT \"question_surveyId_fkey\"" +
+        "                     FOREIGN KEY (\"surveyId\")" +
+        "                     REFERENCES survey(id)" +
+        "                     ON DELETE CASCADE;" +
+        "" +
+        "              ALTER TABLE answer" +
+        "                 DROP CONSTRAINT \"answer_questionId_fkey\"," +
+        "                 ADD CONSTRAINT \"answer_questionId_fkey\"" +
+        "                     FOREIGN KEY (\"questionId\")" +
+        "                     REFERENCES question(id)" +
+        "                     ON DELETE CASCADE;";
+
+    db.runSql(queryString, callback);
+};
+
+exports.down = function(db, callback) {
+    var queryString = "ALTER TABLE question" +
+        "                 DROP CONSTRAINT \"question_surveyId_fkey\"," +
+        "                 ADD CONSTRAINT \"question_surveyId_fkey\"" +
+        "                     FOREIGN KEY (\"surveyId\")" +
+        "                     REFERENCES survey(id);" +
+        "" +
+        "              ALTER TABLE answer" +
+        "                 DROP CONSTRAINT \"answer_questionId_fkey\"," +
+        "                 ADD CONSTRAINT  \"answer_questionId_fkey\"" +
+        "                     FOREIGN KEY (\"questionId\")" +
+        "                     REFERENCES question(id);";
+
+    db.runSql(queryString, callback);
+};

--- a/modules/database.js
+++ b/modules/database.js
@@ -25,12 +25,12 @@ var addQuestions = function(data, callback) {
         var value = question["question"];
         var answers = question["answers"];
 
-        return runQuery("INSERT INTO question(surveyId, value) VALUES($1, $2) RETURNING *", [surveyId, value])
+        return runQuery("INSERT INTO question(\"surveyId\", value) VALUES($1, $2) RETURNING *", [surveyId, value])
         .then(function (results) {
             var questionId = results.rows[0].id;
-            answers.map(function (answer) {
-                return runQuery("INSERT INTO answer(questionId, value) VALUES($1, $2)", [questionId, answer]);
-            })
+            return Q.all(answers.map(function (answer) {
+                return runQuery("INSERT INTO answer(\"questionId\", value) VALUES($1, $2)", [questionId, answer])
+            }))
             .thenResolve();
         });
     }))

--- a/modules/database.js
+++ b/modules/database.js
@@ -26,9 +26,17 @@ var addQuestions = function(data, callback) {
 var removeQuestion = function(data, callback) {
     // var data = {questionId: 2}
     var questionId = data['questionId'];
-    callback(null, {status:"success"});
-};
 
+    runQuery("DELETE FROM question WHERE id=$1", [questionId])
+    .then(function (results) {
+        callback(null, results);
+        return;
+    })
+    .fail(function (error) {
+        callback(error);
+        return;
+    });
+};
 
 var recordVote = function (voteData, callback) {
     // voteData = {'answerId':5, 'questionId':5}

--- a/modules/database.js
+++ b/modules/database.js
@@ -23,8 +23,9 @@ var addQuestions = function(data, callback) {
     return;
 };
 
-var removeQuestions = function(data, callback) {
-    // var data = {questionIds: [2, 4, 5, 8]}
+var removeQuestion = function(data, callback) {
+    // var data = {questionId: 2}
+    var questionId = data['questionId'];
     callback(null, {status:"success"});
 };
 
@@ -218,7 +219,7 @@ exports.getSurveyResults = getSurveyResults;
 exports.getSurveyInfo = getSurveyInfo;
 exports.createSurvey = createSurvey;
 exports.addQuestions = addQuestions;
-exports.removeQuestions = removeQuestions;
+exports.removeQuestion = removeQuestion;
 
 // ==================================================================================================
 // local scope, don't export

--- a/modules/database.js
+++ b/modules/database.js
@@ -5,7 +5,7 @@ var Q = require("q");
 var CONNSTRING = "postgres://postgres:wearetapvote@localhost/tapvotetest";
 
 
-var addQuestion = function(data, callback) {
+var addQuestions = function(data, callback) {
     // { "surveyId":1,
     //   "questions": [
     //       { "question": "Which is best?",
@@ -212,7 +212,7 @@ exports.recordVote = recordVote;
 exports.getSurveyResults = getSurveyResults;
 exports.getSurveyInfo = getSurveyInfo;
 exports.createSurvey = createSurvey;
-exports.addQuestion = addQuestion;
+exports.addQuestion = addQuestions;
 
 // ==================================================================================================
 // local scope, don't export

--- a/modules/database.js
+++ b/modules/database.js
@@ -4,6 +4,26 @@ var Q = require("q");
 // this should be used anytime we need to connect to the DB
 var CONNSTRING = "postgres://postgres:wearetapvote@localhost/tapvotetest";
 
+
+var addQuestion = function(data, callback) {
+    // { "surveyId":1,
+    //   "questions": [
+    //       { "question": "Which is best?",
+    //         "answers": [
+    //              "Puppies",
+    //              "Cheese",
+    //              "Joss Whedon",
+    //              "Naps"
+    //         ]
+    //       }
+    //   ],
+    //   "password":"supersecretpassword" }
+
+    callback(null, {status:"success"});
+    return;
+};
+
+
 var recordVote = function (voteData, callback) {
     // voteData = {'answerId':5, 'questionId':5}
 
@@ -192,7 +212,7 @@ exports.recordVote = recordVote;
 exports.getSurveyResults = getSurveyResults;
 exports.getSurveyInfo = getSurveyInfo;
 exports.createSurvey = createSurvey;
-
+exports.addQuestion = addQuestion;
 
 // ==================================================================================================
 // local scope, don't export

--- a/modules/database.js
+++ b/modules/database.js
@@ -23,6 +23,11 @@ var addQuestions = function(data, callback) {
     return;
 };
 
+var removeQuestions = function(data, callback) {
+    // var data = {questionIds: [2, 4, 5, 8]}
+    callback(null, {status:"success"});
+};
+
 
 var recordVote = function (voteData, callback) {
     // voteData = {'answerId':5, 'questionId':5}
@@ -212,7 +217,8 @@ exports.recordVote = recordVote;
 exports.getSurveyResults = getSurveyResults;
 exports.getSurveyInfo = getSurveyInfo;
 exports.createSurvey = createSurvey;
-exports.addQuestion = addQuestions;
+exports.addQuestions = addQuestions;
+exports.removeQuestions = removeQuestions;
 
 // ==================================================================================================
 // local scope, don't export

--- a/modules/database.js
+++ b/modules/database.js
@@ -35,7 +35,7 @@ var addQuestions = function(data, callback) {
         });
     }))
     .then(function (results) {
-        callback(null, results);
+        callback(null); // status success
     })
     .fail(function (error) {
         callback(error);
@@ -48,7 +48,14 @@ var removeQuestion = function(data, callback) {
 
     runQuery("DELETE FROM question WHERE id=$1", [questionId])
     .then(function (results) {
-        callback(null, results);
+        if(results.rowCount == 0) {
+            var error = Error();
+            error['httpStatus'] = 404;
+            error['httpResponse'] = '404 Not Found';
+            error['friendlyName'] = "questionId does not exist";
+            throw error;
+        }
+        callback(null); // status success
         return;
     })
     .fail(function (error) {


### PR DESCRIPTION
Fixes #90.
Fixes #92.

Implement database methods for `removeQuestion` and `addQuestions`.

From the TapVote repository directory, you will need to run the following commands after pulling in this pull request:

```
$ node_modules/.bin/db-migrate down
$ node_modules/.bin/db-migrate down
$ node_modules/.bin/db-migrate down
$ node_modules/.bin/db-migrate up
```
