### PR TITLE
Add question type param to question table

### DIFF
--- a/migrations/20131121190717-version4.js
+++ b/migrations/20131121190717-version4.js
@@ -1,0 +1,17 @@
+var dbm = require('db-migrate');
+var type = dbm.dataType;
+
+exports.up = function(db, callback) {
+    var queryString = "ALTER TABLE question " +
+        "                  ADD COLUMN type text;" +
+        "              UPDATE question SET type = 'MCSR' WHERE type IS NULL;";
+
+    db.runSql(queryString, callback);
+};
+
+exports.down = function(db, callback) {
+    var queryString = "ALTER TABLE question " +
+        "                  DROP COLUMN type;";
+
+    db.runSql(queryString, callback);
+};

--- a/modules/database.js
+++ b/modules/database.js
@@ -23,9 +23,10 @@ var addQuestions = function(data, callback) {
 
     Q.all(questions.map(function (question) {
         var value = question["question"];
+        var type = question["type"];
         var answers = question["answers"];
 
-        return runQuery("INSERT INTO question(\"surveyId\", value) VALUES($1, $2) RETURNING *", [surveyId, value])
+        return runQuery("INSERT INTO question(\"surveyId\", value, type) VALUES($1, $2) RETURNING *", [surveyId, value, type])
         .then(function (results) {
             var questionId = results.rows[0].id;
             return Q.all(answers.map(function (answer) {

--- a/modules/database.js
+++ b/modules/database.js
@@ -26,7 +26,7 @@ var addQuestions = function(data, callback) {
         var type = question["type"];
         var answers = question["answers"];
 
-        return runQuery("INSERT INTO question(\"surveyId\", value, type) VALUES($1, $2) RETURNING *", [surveyId, value, type])
+        return runQuery("INSERT INTO question(\"surveyId\", value, type) VALUES($1, $2, $3) RETURNING *", [surveyId, value, type])
         .then(function (results) {
             var questionId = results.rows[0].id;
             return Q.all(answers.map(function (answer) {
@@ -221,8 +221,9 @@ var createSurvey = function (surveyData, callback) {
         for (var q=0; q<questions.length; q++) {
             var question = questions[q];
             var value = question['question'];
+            var type = question['type'];
             var answers = question['answers'];
-            runQuery('INSERT INTO question("surveyId", value) VALUES($1, $2) RETURNING *', [sid, value])
+            runQuery('INSERT INTO question("surveyId", value, type) VALUES($1, $2, $3) RETURNING *', [sid, value, type])
 
             .then(function (result) {
                 // insert all the answers for this question

--- a/routes/addQuestions.js
+++ b/routes/addQuestions.js
@@ -3,7 +3,7 @@ var httpresponses = require("../modules/httpresponses");
 var endpoint = require("../modules/endpoint");
 
 //Test this endpoint with
-//curl -d '{ "surveyId":1, "questions": [{"question": "Which is best?", "answers": ["Puppies", "Cheese", "Joss Whedon", "Naps"]}],"password":"supersecretpassword" }' -H "Content-Type: application/json" http://localhost:8000/addQuestions
+//curl -d '{ "surveyId":1, "questions": [{"question": "Which is best?", "type":"MCSR", "answers": ["Puppies", "Cheese", "Joss Whedon", "Naps"]}],"password":"supersecretpassword" }' -H "Content-Type: application/json" http://localhost:8000/addQuestions
 
 function addQuestions(){
     var apiOptions = {};

--- a/routes/createSurvey.js
+++ b/routes/createSurvey.js
@@ -3,7 +3,7 @@ var httpresponses = require("../modules/httpresponses");
 var endpoint = require("../modules/endpoint");
 
 //Test this endpoint with
-//curl -d '{ "title":"\"Because clickers are SO 1999.\"", "questions": [{"question": "Which is best?", "answers": ["Puppies", "Cheese", "Joss Whedon", "Naps"]}],"password":"supersecretpassword" }' -H "Content-Type: application/json" http://localhost:8000/createSurvey
+//curl -d '{ "title":"\"Because clickers are SO 1999.\"", "questions": [{"question": "Which is best?", "type":"MCSR", "answers": ["Puppies", "Cheese", "Joss Whedon", "Naps"]}],"password":"supersecretpassword" }' -H "Content-Type: application/json" http://localhost:8000/createSurvey
 
 function createSurvey(){
     var apiOptions = {};

--- a/tests/database.js
+++ b/tests/database.js
@@ -7,7 +7,7 @@ var database = require('../modules/database');
 describe("Database", function(){
     describe("createSurvey", function(){
         it("inserts a survey with questions and answers into the database", function(done) {
-            database.createSurvey({ "title":"Test survey with questions and answers", "questions": [{"question": "Question 1", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]}],"password":"supersecretpassword" },function(err,results) {
+            database.createSurvey({ "title":"Test survey with questions and answers", "questions": [{"question": "Question 1", "type":"MCSR", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]}],"password":"supersecretpassword" },function(err,results) {
                 try {
                     should.not.exist(err);
                     done();
@@ -17,7 +17,7 @@ describe("Database", function(){
             });
         });
         it("inserts a survey with two questions and answers into the database", function(done) {
-            database.createSurvey({ "title":"Test survey with two questions and answers", "questions": [{"question": "Question 1", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]},{"question": "Question 2", "answers": ["Q2a1", "Q2a2", "Q2a3", "Q2a4"]}],"password":"supersecretpassword" },function(err,results) {
+            database.createSurvey({ "title":"Test survey with two questions and answers", "questions": [{"question": "Question 1", "type":"MCSR", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]},{"question": "Question 2", "type":"MCSR", "answers": ["Q2a1", "Q2a2", "Q2a3", "Q2a4"]}],"password":"supersecretpassword" },function(err,results) {
                 try {
                     should.not.exist(err);
                     done();
@@ -39,7 +39,7 @@ describe("Database", function(){
     });
     describe("addQuestions", function(){
         it("inserts questions and answers into the database for a survey that already has questions into the database", function(done) {
-            database.addQuestions({ "surveyId":1, "questions": [{"question": "Question 1", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]}],"password":"supersecretpassword" },function(err,results) {
+            database.addQuestions({ "surveyId":1, "questions": [{"question": "Question 1", "type":"MCSR", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]}],"password":"supersecretpassword" },function(err,results) {
                 try {
                     should.not.exist(err);
                     done();
@@ -49,7 +49,7 @@ describe("Database", function(){
             });
         });
         it("inserts two questions and answers for a survey that already has questions into the database", function(done) {
-            database.addQuestions({ "surveyId":1, "questions": [{"question": "Question 1", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]},{"question": "Question 2", "answers": ["Q2a1", "Q2a2", "Q2a3", "Q2a4"]}],"password":"supersecretpassword" },function(err,results) {
+            database.addQuestions({ "surveyId":1, "questions": [{"question": "Question 1", "type":"MCSR", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]},{"question": "Question 2", "type":"MCSR", "answers": ["Q2a1", "Q2a2", "Q2a3", "Q2a4"]}],"password":"supersecretpassword" },function(err,results) {
                 try {
                     should.not.exist(err);
                     done();
@@ -59,7 +59,7 @@ describe("Database", function(){
             });
         });
         it.skip("inserts questions and answers into the database for a survey that has no questions into the database", function(done) {
-            database.addQuestions({ "surveyId":1, "questions": [{"question": "Question 1", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]}],"password":"supersecretpassword" },function(err,results) {
+            database.addQuestions({ "surveyId":1, "questions": [{"question": "Question 1", "type":"MCSR", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]}],"password":"supersecretpassword" },function(err,results) {
                 try {
                     should.not.exist(err);
                     done();
@@ -69,7 +69,7 @@ describe("Database", function(){
             });
         });
         it.skip("inserts two questions and answers into the database for a survey that has no questions into the database", function(done) {
-            database.addQuestions({ "surveyId":1, "questions": [{"question": "Question 1", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]}],"password":"supersecretpassword" },function(err,results) {
+            database.addQuestions({ "surveyId":1, "questions": [{"question": "Question 1", "type":"MCSR", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]}],"password":"supersecretpassword" },function(err,results) {
                 try {
                     should.not.exist(err);
                     done();


### PR DESCRIPTION
Fixes #94.

You will need to run the following command to apply the new schema. (From the repository directory):

```
$ node_modules/.bin/db-migrate up
```

This adds the column `type` to the question table. This allow updates the addQuestions and createSurvey database methods to use the new field.

Any questions already in the database when this schema migration is run are assumed to be multiple-choice single-response (MCSR).

I'm not doing any checking in code on this, but I'm expecting that the types we'll use are:

MCSR <-- multiple choice, single response
MCMR <-- multiple choice, multiple response
FR <-- free response (not implemented for this milestone)
MCRANK <-- multiple choice, ranked responses
