### PR TITLE
Implement MCMR; Add /deVote API endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ require('./modules/globals');
  */
 var express = require('express');
 var vote = require('./routes/vote');
+var deVote = require('./routes/deVote');
 var getSurveyResults = require('./routes/getSurveyResults');
 var getSurveyInfo = require('./routes/getSurveyInfo');
 var createSurvey = require('./routes/createSurvey');
@@ -37,6 +38,7 @@ if ('development' == app.get('env')) {
 }
 
 app.post('/vote', vote.vote());
+app.post('/deVote', deVote.deVote());
 app.post('/createSurvey', createSurvey.createSurvey());
 app.post('/addQuestions', addQuestions.addQuestions());
 app.post('/removeQuestion', removeQuestion.removeQuestion());

--- a/modules/database/deleteVote.js
+++ b/modules/database/deleteVote.js
@@ -5,8 +5,43 @@ var runQuery = require("./runQuery").runQuery;
 var deleteVote = function (data, callback) {
     // data = {"questionId":5, "answerId":3}
 
-    // TODO implement this
-    callback(null, {"status":"success"});
+    // need to check that data['answerId'] has a questionId == data['questionId']
+    runQuery('SELECT "questionId" FROM answer WHERE id=$1', [data['answerId']])
+    .then(function (results) {
+        var qid = results.rows[0].questionId;
+        if(qid == data['questionId']) {
+          return;
+        } else {
+          throw Error();
+        }
+    })
+    .then(function (results) {
+        // This query is needed because Postgres doesn't support LIMIT in DELETE queries.
+        // Here we're relying on the ctid column, which is the physical location of the row. It's not
+        // a stable identifier over UPDATES, etc, but it works for this situation.
+        // See for more info:
+        // http://www.postgresql.org/message-id/07f0833692070125b9317094e7008b4f@biglumber.com
+        var queryString = 'DELETE FROM vote WHERE ctid = (SELECT ctid FROM vote WHERE "questionId"=$1 AND "answerId"=$2 LIMIT 1)';
+        runQuery(queryString, [data['questionId'], data['answerId']])
+        .then(function (res) {
+            logger.info("Query success: deleted vote from database");
+            callback(null, res);
+            return;
+        })
+        .fail(function (error) {
+            logger.error("Query fail: error deleting vote from database");
+            callback(error);
+            return;
+        })
+    })
+    .fail(function (error) {
+        logger.error("Question doesn't have that answer as an option.", error);
+        error['httpStatus'] = 400;
+        error['httpResponse'] = '400 Bad Request';
+        error['friendlyName'] = "questionId and answerId don't match";
+        callback(error);
+        return;
+    });
 };
 
 exports.deleteVote = deleteVote;

--- a/modules/database/recordVote.js
+++ b/modules/database/recordVote.js
@@ -7,37 +7,35 @@ var recordVote = function (voteData, callback) {
 
     // need to check that voteData['answerId'] has a questionId == voteData['questionId']
     runQuery('SELECT "questionId" FROM answer WHERE id=$1', [voteData['answerId']])
+    .then(function (results) {
+        var qid = results.rows[0].questionId;
+        if(qid == voteData['questionId']) {
+          return;
+        } else {
+          throw Error();
+        }
+    })
+    .then(function (results) {
+        runQuery('INSERT INTO vote("answerId", "questionId") VALUES($1, $2)', [voteData['answerId'], voteData['questionId']])
         .then(function (results) {
-                  var qid = results.rows[0].questionId;
-                  if(qid == voteData['questionId']) {
-                      return;
-                  } else {
-                      throw Error();
-                  }
-              })
-        .then(function (results) {
-                  runQuery('INSERT INTO vote("answerId", "questionId") VALUES($1, $2)', [voteData['answerId'], voteData['questionId']])
-                      .then(function (results) {
-                                logger.info("Recorded vote in database.");
-                                callback(null, results);
-                                return;
-                            })
-                      .fail(function (error) {
-                                logger.error("Error logging vote to database.", error);
-                                callback(error);
-                                return;
-                            });
-
-              })
+                logger.info("Recorded vote in database.");
+                callback(null, results);
+                return;
+        })
         .fail(function (error) {
-                  logger.error("Question doesn't have that answer as an option.", error);
-                  error['httpStatus'] = 400;
-                  error['httpResponse'] = '400 Bad Request';
-                  error['friendlyName'] = "questionId and answerId don't match";
-                  callback(error);
-                  return;
-              });
+                logger.error("Error logging vote to database.", error);
+                callback(error);
+                return;
+        });
+    })
+    .fail(function (error) {
+        logger.error("Question doesn't have that answer as an option.", error);
+        error['httpStatus'] = 400;
+        error['httpResponse'] = '400 Bad Request';
+        error['friendlyName'] = "questionId and answerId don't match";
+        callback(error);
+        return;
+    });
 };
-
 
 exports.recordVote = recordVote;

--- a/public/javascript/takesurvey.js
+++ b/public/javascript/takesurvey.js
@@ -50,27 +50,41 @@ function displaySurvey(results) {
         questionTitle.text(question['value']);
         questionDiv.append(questionTitle);
 
+        var questionType = question['type'];
+        var questionId = question['id'];
+
         var answers = question['answers'];
         $.each(answers, function (index, answer) {
+            var answerId = answer['id'];
+            var answerValue = answer['value'];
+
             var answerDiv = $("<div></div>");
-            answerDiv.attr('id', 'answer-'+answer['id']);
+            answerDiv.attr('id', 'answer-'+answerId);
             answerDiv.attr('class', 'answer');
 
-            var radioAnswerId = answer['id'];
-            var radioQuestionId = question['id'];
-            var radioName = 'question-' + question['id'] + '-answer';
+            var answerEl = $("<input />"); // the actual input element (radio, checkbox, etc)
+            answerEl.attr('id', 'answer-'+questionType+'-'+answerId);
 
-            var radioOnclick = 'submitVote(' + radioQuestionId + ',' + radioAnswerId + ')';
-            var answerOptionHtml = "<input type='radio'" +
-                                          "value='" + radioAnswerId + "'" +
-                                          "name='" + radioName + "'" +
-                                          "onclick='" + radioOnclick + ";'>" +
-                                          answer['value'] +
-                                   "</input>";
-            var answerValue = $(answerOptionHtml);
+            if (questionType == "MCSR") {
+                answerEl.attr('name', 'question-'+questionId+'-answers');
+                answerEl.attr('type', 'radio');
+                answerEl.attr('onclick', 'submitVote('+questionId + ', ' + answerId + ');');
+            }
 
-            answerDiv.append(answerValue);
+            if (questionType == "MCMR") {
+                answerEl.attr('type', 'checkbox');
+            }
+
+            answerDiv.append(answerEl);
+
+            // make the label (containing the value of the answer_
+            var answerLabel = $("<label></label>");
+            answerLabel.attr('for', 'answer-'+questionType+'-'+answerId);
+            answerLabel.text(answerValue);
+            answerDiv.append(answerLabel);
+
             questionDiv.append(answerDiv);
+
         });
         questionsDiv.append(questionDiv);
     });

--- a/public/javascript/takesurvey.js
+++ b/public/javascript/takesurvey.js
@@ -71,7 +71,6 @@ function displaySurvey(results) {
             if (questionType == "MCSR") {
                 answerEl.attr('name', 'question-'+questionId+'-answers');
                 answerEl.attr('type', 'radio');
-                // 'change' event is *not* fired on deselected element, only the selected element
                 answerEl.change(checkMCSR);
             }
 
@@ -80,6 +79,18 @@ function displaySurvey(results) {
                 // this works for checkbox because the 'change' event is fired on deselect as well as select
                 answerEl.change(checkMCMR);
             }
+
+            else {
+                // unimplemented question type (i.e. MCRANK, FR, etc)
+                console.log("WARNING: Encountered an unimplmemented question type: " + questionType);
+                console.log("WARNING: Treating unknown type as MCSR!");
+
+                // just treat this unkown type as an MCSR
+                answerEl.attr('name', 'question-'+questionId+'-answers');
+                answerEl.attr('type', 'radio');
+                answerEl.change(checkMCSR);
+            }
+
 
             answerDiv.append(answerEl);
 

--- a/public/javascript/takesurvey.js
+++ b/public/javascript/takesurvey.js
@@ -1,5 +1,6 @@
 // GLOBAL PAGE VARIABLES //
 pageTitle = "Take Survey";
+var previousMCSR = {};
 
 $(function getSurveyInfo() {
     var survey = $.QueryString['survey'];
@@ -67,17 +68,17 @@ function displaySurvey(results) {
             answerEl.attr('data-question-id', questionId);
             answerEl.attr('data-answer-id', answerId);
 
-
             if (questionType == "MCSR") {
                 answerEl.attr('name', 'question-'+questionId+'-answers');
                 answerEl.attr('type', 'radio');
-                //answerEl.attr('onclick', 'submitVote('+questionId + ', ' + answerId + ');');
-                answerEl.change(checkMC);
+                // 'change' event is *not* fired on deselected element, only the selected element
+                answerEl.change(checkMCSR);
             }
 
             if (questionType == "MCMR") {
                 answerEl.attr('type', 'checkbox');
-                answerEl.change(checkMC);
+                // this works for checkbox because the 'change' event is fired on deselect as well as select
+                answerEl.change(checkMCMR);
             }
 
             answerDiv.append(answerEl);
@@ -98,7 +99,23 @@ function displaySurvey(results) {
     console.log(results);
 }
 
-function checkMC(event) {
+function checkMCSR(event) {
+    var el = $(this);
+    var questionId = parseInt(el.attr('data-question-id'));
+    var answerId = parseInt(el.attr('data-answer-id'));
+
+    // send a deVote for the old answer before submitting the new vote
+    var prevAnswerId = previousMCSR['questionId'];
+    if (prevAnswerId) {
+        deVote(questionId, prevAnswerId);
+    }
+
+    // send vote for newly select answer, and remember this vote
+    previousMCSR['questionId'] = answerId;
+    submitVote(questionId, answerId);
+}
+
+function checkMCMR(event) {
     var el = $(this);
     var questionId = parseInt(el.attr('data-question-id'));
     var answerId = parseInt(el.attr('data-answer-id'));

--- a/public/javascript/takesurvey.js
+++ b/public/javascript/takesurvey.js
@@ -74,7 +74,7 @@ function displaySurvey(results) {
                 answerEl.change(checkMCSR);
             }
 
-            if (questionType == "MCMR") {
+            else if (questionType == "MCMR") {
                 answerEl.attr('type', 'checkbox');
                 // this works for checkbox because the 'change' event is fired on deselect as well as select
                 answerEl.change(checkMCMR);
@@ -85,7 +85,7 @@ function displaySurvey(results) {
                 console.log("WARNING: Encountered an unimplmemented question type: " + questionType);
                 console.log("WARNING: Treating unknown type as MCSR!");
 
-                // just treat this unkown type as an MCSR
+                // just treat this unknown type as an MCSR
                 answerEl.attr('name', 'question-'+questionId+'-answers');
                 answerEl.attr('type', 'radio');
                 answerEl.change(checkMCSR);
@@ -116,14 +116,14 @@ function checkMCSR(event) {
     var answerId = parseInt(el.attr('data-answer-id'));
 
     // send a deVote for the old answer before submitting the new vote
-    var prevAnswerId = previousMCSR['questionId'];
+    var prevAnswerId = previousMCSR[questionId];
     if (prevAnswerId) {
         deVote(questionId, prevAnswerId);
     }
 
     // send vote for newly select answer, and remember this vote (so that we can properly
     // deVote if the user changes their vote)
-    previousMCSR['questionId'] = answerId;
+    previousMCSR[questionId] = answerId;
     submitVote(questionId, answerId);
 }
 

--- a/public/javascript/takesurvey.js
+++ b/public/javascript/takesurvey.js
@@ -117,7 +117,7 @@ function checkMCSR(event) {
 
     // send a deVote for the old answer before submitting the new vote
     var prevAnswerId = previousMCSR[questionId];
-    if (prevAnswerId) {
+    if (prevAnswerId || prevAnswerId === 0) {
         deVote(questionId, prevAnswerId);
     }
 

--- a/public/javascript/takesurvey.js
+++ b/public/javascript/takesurvey.js
@@ -71,12 +71,13 @@ function displaySurvey(results) {
             if (questionType == "MCSR") {
                 answerEl.attr('name', 'question-'+questionId+'-answers');
                 answerEl.attr('type', 'radio');
-                answerEl.attr('onclick', 'submitVote('+questionId + ', ' + answerId + ');');
+                //answerEl.attr('onclick', 'submitVote('+questionId + ', ' + answerId + ');');
+                answerEl.change(checkMC);
             }
 
             if (questionType == "MCMR") {
                 answerEl.attr('type', 'checkbox');
-                answerEl.change(checkMCMR);
+                answerEl.change(checkMC);
             }
 
             answerDiv.append(answerEl);
@@ -97,16 +98,16 @@ function displaySurvey(results) {
     console.log(results);
 }
 
-function checkMCMR(event) {
+function checkMC(event) {
     var el = $(this);
     var questionId = parseInt(el.attr('data-question-id'));
     var answerId = parseInt(el.attr('data-answer-id'));
 
-    if(this.checked) {
+    if (this.checked) {
         submitVote(questionId, answerId);
     }
 
-    if(! this.checked) {
+    if (! this.checked) {
         deVote(questionId, answerId);
     }
 }

--- a/public/javascript/takesurvey.js
+++ b/public/javascript/takesurvey.js
@@ -121,7 +121,8 @@ function checkMCSR(event) {
         deVote(questionId, prevAnswerId);
     }
 
-    // send vote for newly select answer, and remember this vote
+    // send vote for newly select answer, and remember this vote (so that we can properly
+    // deVote if the user changes their vote)
     previousMCSR['questionId'] = answerId;
     submitVote(questionId, answerId);
 }
@@ -131,10 +132,12 @@ function checkMCMR(event) {
     var questionId = parseInt(el.attr('data-question-id'));
     var answerId = parseInt(el.attr('data-answer-id'));
 
+    // if newly checked, submit a vote
     if (this.checked) {
         submitVote(questionId, answerId);
     }
 
+    // if unchecked, send a deVote
     if (! this.checked) {
         deVote(questionId, answerId);
     }

--- a/public/javascript/takesurvey.js
+++ b/public/javascript/takesurvey.js
@@ -64,6 +64,9 @@ function displaySurvey(results) {
 
             var answerEl = $("<input />"); // the actual input element (radio, checkbox, etc)
             answerEl.attr('id', 'answer-'+questionType+'-'+answerId);
+            answerEl.attr('data-question-id', questionId);
+            answerEl.attr('data-answer-id', answerId);
+
 
             if (questionType == "MCSR") {
                 answerEl.attr('name', 'question-'+questionId+'-answers');
@@ -73,6 +76,7 @@ function displaySurvey(results) {
 
             if (questionType == "MCMR") {
                 answerEl.attr('type', 'checkbox');
+                answerEl.change(checkMCMR);
             }
 
             answerDiv.append(answerEl);
@@ -93,8 +97,35 @@ function displaySurvey(results) {
     console.log(results);
 }
 
+function checkMCMR(event) {
+    var el = $(this);
+    var questionId = parseInt(el.attr('data-question-id'));
+    var answerId = parseInt(el.attr('data-answer-id'));
+
+    if(this.checked) {
+        submitVote(questionId, answerId);
+    }
+
+    if(! this.checked) {
+        deVote(questionId, answerId);
+    }
+}
+
+function deVote(questionId, answerId) {
+    var data = { "questionId": questionId, "answerId": answerId};
+
+    $.ajax({
+        type: 'POST',
+        url: '/deVote',
+        data: JSON.stringify(data),
+        contentType: "application/json",
+        success: function (results) { console.log(results); },
+        error: function (results) { console.log(results); }
+    })
+}
+
 function submitVote(questionId, answerId) {
-    var data = { questionId: questionId, answerId: answerId};
+    var data = { "questionId": questionId, "answerId": answerId};
 
     $.ajax({
         type: 'POST',

--- a/routes/deVote.js
+++ b/routes/deVote.js
@@ -1,0 +1,56 @@
+var database = require("../modules/database");
+var httpresponses = require("../modules/httpresponses");
+var endpoint = require("../modules/endpoint");
+
+function deVote(){
+    var apiOptions = {};
+    
+    //The name of this route:
+    apiOptions.endpointName = "deVote";
+        
+    //Indicates the required API parameters and their basic expected types.
+    apiOptions.requiredApiParameters = {
+            "answerId":"number",
+            "questionId":"number"};
+    //Indicates the optional API parameters and their basic expected types.
+    apiOptions.optionalApiParameters = {
+            "surveyId":"number"};
+    
+    //Provides additional validation functions after the basic check on required parameters. 
+    //If a parameter is listed in this object, it MUST validate successfully and return true if provided in the request.
+    //In the case of a problem, return false or throw an error.
+    apiOptions.validators = {};
+    
+    //Function to execute if validation tests are successful.
+    apiOptions.conclusion = function(data, response) {
+        logger.info("Incoming deVote: " + data);
+        // TODO update with actual data (timestamp, uid, etc?)
+        database.deleteVote(data, function(err, results) {
+            if (err) {
+                if (!err["httpStatus"])
+                    err["httpStatus"] = 500;
+
+                if(!err["httpResponse"])
+                    err["httpResponse"] = "500 Internal Server Error";
+
+                if (!err["friendlyName"])
+                    err["friendlyName"] = "Error deleting vote";
+
+                httpresponses.errorResponse(err, response);
+                return;
+            }
+            else {
+                logger.info("Deleted vote from database");
+                httpresponses.successResponse(response);
+                return;
+            }
+        });
+    };
+    
+    var endpointObject = new endpoint.Endpoint(apiOptions);
+    return function() {  
+        (endpointObject.handle).apply(endpointObject, arguments);  
+    }; //return the handler function for the endpoint
+}
+
+exports.deVote = deVote;


### PR DESCRIPTION
Fixes #79.
This implements a new question type (MCMR). The ability to remove a vote is also present. If a user unchecks an answer option, that vote is removed from the database.

Fixes #127.
Fixes #128.
Adds a new API endpoint (`/deVote`) and corresponding database method. `/deVote` is given a `questionId` and `answerId` and removes an entry in the `vote` table. (If there are multiple votes for the `questionId` and `answerId` combination, it just removes one of them). 

Fixes #132.
One vote per question is now enforced for MCSR questions. If the user changes their vote, the previous vote is removed (using `/deVote`) before the new one is submitted.

Misc:
If `takesurvey.html` encounters a question type that isn't yet implemented (i.e. anything other than MCSR and MCMR, it logs a warning to the console, and treats the unknown type as MCSR). 
