### PR TITLE
Database password management

### DIFF
--- a/modules/database/runQuery.js
+++ b/modules/database/runQuery.js
@@ -3,7 +3,15 @@ var pg = require("pg"); // PostgreSQL client library
 
 
 // this should be used anytime we need to connect to the DB
-var CONNSTRING = "postgres://postgres:wearetapvote@localhost/tapvotetest";
+var CONNSTRING;
+var dbPassword = process.env.TAPVOTE_DATABASE_PASSWORD;
+
+// if it's set in the environment, use that password. Otherwise, use "wearetapvote"
+if (dbPassword)
+    CONNSTRING = "postgres://postgres:" + dbPassword + "@localhost/tapvotetest";
+else
+    CONNSTRING = "postgres://postgres:wearetapvote@localhost/tapvotetest";
+
 
 var runQuery = function (queryString, values) {
     var deferred = Q.defer();


### PR DESCRIPTION
Fixes #115.

This allows us to set different database passwords for different environments. If the environment variable `TAPVOTE_DATABASE_PASSWORD` is set, that value will be used as the password to the Postgres database (the database name is still hard-coded `tapvotetest`).

If the environment variable is not set, it will continue to use `wearetapvote`. 

I don't see any harm in continuing to use `wearetapvote` on development machines, but I'm going to set up the "production" server to use a different password.
