### PR TITLE
Add/remove questions from the admin page

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -1,8 +1,26 @@
 <div id="admin-content">
-  <div id="survey">
+  <form class="pure-form pure-form-stacked">
+    <div id="survey">
+      <div id="survey-title"></div>
+      <div id="survey-questions"></div>
+    </div>
 
-    <div id="survey-title"></div>
-    <div id="survey-questions"></div>
+    <div class="align-left">
+      <button type="button"
+              class="pure-button pure-button-success pure-button-small"
+              data-dropdown="#question-type-dropdown">Create Question</button>
+    </div>
+  </form>
+
+    <!-- below is the div containing the dropdown menu for question type selection -->
+  <div id="question-type-dropdown" class="dropdown">
+    <ul class="dropdown-menu">
+      <li><a href="javascript:createQuestion('MCSR')">Multiple Choice, Single Response</a></li>
+      <li><a href="javascript:createQuestion('MCMR')">Multiple Choice, Multiple Choice</a></li>
+      <li class="disabled"><a href="javascript:createQuestion('MCRANK')">Multiple Choice, Ranked Response</a></li>
+      <li class="disabled"><a href="javascript:createQuestion('FR')">Free Response</a></li>
+    </ul>
   </div>
+
   <script type="text/javascript" src="javascript/admin.js"> </script>
 </div>

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,7 +1,5 @@
 <div id="admin-content">
   <div id="survey">
-    IMPORTANT: this page is the same as results.html right now. We need to fix this so that it actually does admin
-    functionality. <br><br>
 
     <div id="survey-title"></div>
     <div id="survey-questions"></div>

--- a/public/admin.html
+++ b/public/admin.html
@@ -5,11 +5,7 @@
       <div id="survey-questions"></div>
     </div>
 
-    <div class="align-left">
-      <button type="button"
-              class="pure-button pure-button-success pure-button-small"
-              data-dropdown="#question-type-dropdown">Create Question</button>
-    </div>
+    <div id="create-question-button-container" class="align-left"></div>
   </form>
 
     <!-- below is the div containing the dropdown menu for question type selection -->

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -210,6 +210,10 @@ h3 {
     width: 270px;
 }
 
+.align-left {
+    text-align: left;
+}
+
 .disabled a {
     color: grey !important;
     text-decoration: line-through !important;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -294,7 +294,7 @@ h3 {
 /* target Firefox only with this rule - Firefox has some spacing oddities w/ inline-block elements */
 @-moz-document url-prefix() {
     .add-answer-button {
-        vertical-align: -4px;
+        vertical-align: -4px !important;
     }
 }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -129,7 +129,7 @@ h3 {
 }
 
 .survey-id-input-box {
-    margin-top: 8px;
+    margin-top: 8px !important;
 }
 
 .highlight-orange {
@@ -196,7 +196,7 @@ h3 {
 
 #take-survey-button,
 #see-results-button,
-#edit-survey-button, {
+#edit-survey-button {
     margin-left: 6px;
 }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -57,7 +57,6 @@ h3 {
 .questions {
     margin-top: 20px;
     text-align: left;
-    max-width: 500px;
 }
 
 .answers {
@@ -80,6 +79,7 @@ h3 {
 .question-title {
     font-weight: bold;
     margin-bottom: 5px;
+    margin-top: 5px;
 }
 
 .question-text {
@@ -162,7 +162,8 @@ h3 {
 
 #home-content,
 #takesurvey-content,
-#results-content {
+#results-content,
+#admin-content {
     /* some of the pages should be aligned centered (e.g. home) */
     text-align: center
 }
@@ -194,7 +195,8 @@ h3 {
 
 
 #take-survey-button,
-#see-results-button {
+#see-results-button,
+#edit-survey-button, {
     margin-left: 6px;
 }
 

--- a/public/footer.html
+++ b/public/footer.html
@@ -3,6 +3,7 @@
     <a href="/">Home</a> |
     <a href="/?p=takesurvey">Take Survey</a> |
     <a href="/?p=createsurvey">Create Survey</a> |
+    <a href="/?p=admin">Edit Survey</a> |
     <a href="/?p=results">Show Results</a>
   </span>
   <span id="copyright">Copyright &copy; 2013 TapVote.</span>

--- a/public/javascript/admin.js
+++ b/public/javascript/admin.js
@@ -109,15 +109,15 @@ function displaySurvey(results) {
 /* create the HTML for a new question form - doesn't actually submit anything to the server */
 function createQuestion(type) {
     var questionHtml = '<div class="question rounded ' + type + '" data-question-type="'+type+'">' +
-        '  <button type="button" class="remove-question-button pure-button pure-button-error" onclick="removeQuestion(this);"><i class="fa fa-times fa-lg"></i></button> ' +
+        '  <button type="button" class="remove-question-button pure-button pure-button-error" onclick="removeQuestionElement(this);"><i class="fa fa-times fa-lg"></i></button> ' +
         '  <label for="question-text">Question</label><input type="text" class="question-text" />' +
         '  <div class="answers">' +
         '    <div class="answer">' +
         '     <label for="answer-text">Answer Choice</label><input type="text" class="answer-text no-wrap" />' +
-        '     <button type="button" class="remove-answer-button pure-button pure-button-error" onclick="removeAnswer(this);"><i class="fa fa-times"></i></button><br>' +
+        '     <button type="button" class="remove-answer-button pure-button pure-button-error" onclick="removeAnswerElement(this);"><i class="fa fa-times"></i></button><br>' +
         '    </div>' +
         '  </div>' +
-        '  <button type="button" class="add-answer-button pure-button pure-button-success pure-button-small" style="vertical-align:-7px;" onclick="addAnswer(this);"><i class="fa fa-plus"></i></button>' +
+        '  <button type="button" class="add-answer-button pure-button pure-button-success pure-button-small" style="vertical-align:-7px;" onclick="addAnswerElement(this);"><i class="fa fa-plus"></i></button>' +
         '  <button type="button" class="pure-button pure-button-primary pure-button-small" onclick="saveQuestion(this);">Save Question</button>' +
         '</div>';
 
@@ -165,7 +165,7 @@ function updateNewQuestion(questionDiv, serverResponse) {
 }
 
 /* remove the HTML for a new (unsubmitted) question */
-function removeQuestion(el) {
+function removeQuestionElement(el) {
     var target = $(el);
     var questionDiv = target.parent();
     questionDiv.remove();
@@ -187,11 +187,11 @@ function deleteQuestion(el) {
     });
 }
 
-function addAnswer(el) {
+function addAnswerElement(el) {
     // find the question, add another answer option
     var answerHtml = '<div class="answer">' +
         '  <label for="answer-text">Answer Choice</label><input type="text" class="answer-text no-wrap" />' +
-        '  <button type="button" class="remove-answer-button pure-button pure-button-error" onclick="removeAnswer(this);"><i class="fa fa-times"></i></button><br>' +
+        '  <button type="button" class="remove-answer-button pure-button pure-button-error" onclick="removeAnswerElement(this);"><i class="fa fa-times"></i></button><br>' +
         '</div>';
 
     var target = $(el); // this will be the + button (with name=question-%questionId%)
@@ -199,7 +199,7 @@ function addAnswer(el) {
     answersDiv.append(answerHtml);
 }
 
-function removeAnswer(el) {
+function removeAnswerElement(el) {
     var target = $(el);
     var answerDiv = target.parent();
 

--- a/public/javascript/admin.js
+++ b/public/javascript/admin.js
@@ -1,74 +1,90 @@
-/**
- * Created by isaac on 10/29/13.
- */
-
 // GLOBAL PAGE VARIABLES //
 pageTitle = "Admin";
 
 
 $(function getSurveyInfo() {
     var survey = $.QueryString['survey'];
-    $.ajax({
-        type:'GET',
-        url: '/getSurveyInfo',
-        data: {surveyId: survey},
-        success: displaySurveyInfo,
-        error: displayAjaxError
-    });
+    if (survey) {
+        $.ajax({
+            type:'GET',
+            url: '/getSurveyInfo',
+            data: {surveyId: survey},
+            success: displaySurvey,
+            error: displayAjaxError
+        });
+    } else {
+        askForSurveyId();
+    }
 });
 
-function getSurveyResults() {
-    var survey = $.QueryString['survey'];
-    $.ajax({
-        type:'GET',
-        url: '/getSurveyResults',
-        data: {surveyId: survey},
-        success: displaySurveyResults,
-        error: displayAjaxError
-    });
+function askForSurveyId() {
+    // This function is called when a survey Id isn't provided or when an invalid sId is given
+    var titleDiv = $("#survey-title");
+    titleDiv.text("Please enter a survey ID and click 'Edit Survey'.");
+
+    var idBox = $("<input id='survey-id' class='no-wrap survey-id-input-box' type='text' size=5 />");
+    var button = $("<button type='button' id='edit-survey-button'>Edit Survey</button>");
+    button.addClass("pure-button pure-button-success pure-button-small");
+    button.attr('onclick', 'redirectToSurvey()');
+
+    var form = $("<form></form>");
+    form.addClass("pure-form");
+    form.attr("action", "javascript:$('#edit-survey-button').click();");
+    form.append(idBox);
+    form.append(button);
+
+    var surveyDiv = $("#survey-questions");
+    surveyDiv.append(form);
+}
+
+function redirectToSurvey() {
+    window.location.href="/?p=admin&survey=" + $("#survey-id").val();
 }
 
 function displayAjaxError(error) {
-    console.log(error.statusText);
-    console.log(error.responseText);
-    var titleDiv = $("#survey-title");
-    titleDiv.text("Error getting survey or results. Did you specify a non-existent survey id?");
+    if (error.status == 404)
+        askForSurveyId(); // 404 happens when an invalid survey ID is specified
+    else
+        console.log(error);
 }
 
-function displaySurveyResults(results) {
-    $.each(results, function (key, value) {
-        var elementId = '#answer-' + key;
-        var resultSpan = $("<span></span>");
-        resultSpan.text(value);
-
-        $(elementId).append(resultSpan);
-    });
-    console.log(results);
-}
-
-function displaySurveyInfo(results) {
+function displaySurvey(results) {
     var titleDiv = $("#survey-title");
 
-    var el = $("<h2></h2>");
+    var el = $("<div></div>");
     el.text(results['title']);
+    el.prepend("<i class='fa fa-pencil' onclick='editSurveyTitle();'></i>");
+    el.addClass('survey-title');
     titleDiv.append(el);
 
     var questionsDiv = $("#survey-questions");
+    questionsDiv.addClass("questions");
+
     var questions = results['questions'];
     $.each(questions, function (index, question) {
         // create a div for each question in questions
         var questionDiv = $("<div></div>");
-        questionDiv.attr('id', 'question-'+question['id']);
-        questionDiv.attr('class', 'question');
+        questionDiv.attr('data-question-id', question['id']);
+        questionDiv.attr('class', 'question rounded');
+
+        var deleteQuestionButton = $("<button></button>");
+        deleteQuestionButton.attr("type", "button");
+        deleteQuestionButton.addClass("remove-question-button pure-button pure-button-error");
+        deleteQuestionButton.attr("onclick", "deleteQuestion(this);");
+        deleteQuestionButton.html("<i class='fa fa-times fa-lg'></i>");
+        questionDiv.append(deleteQuestionButton);
+
 
         var questionTitle = $("<div></div>");
         questionTitle.text(question['value']);
+        questionTitle.addClass('question-title');
         questionDiv.append(questionTitle);
 
         var answers = question['answers'];
         $.each(answers, function (index, answer) {
             var answerDiv = $("<div></div>");
-            answerDiv.attr('id', 'answer-'+answer['id']);
+            answerDiv.attr('data-question-id', question['id']);
+            answerDiv.attr('data-answer-id', answer['id']);
             answerDiv.attr('class', 'answer');
 
             var questionValue = $("<div></div>");
@@ -83,7 +99,28 @@ function displaySurveyInfo(results) {
     });
 
     console.log(results);
-    getSurveyResults();
+}
+
+function deleteQuestion(el) {
+    var target = $(el);
+    var questionDiv = target.parent();
+
+    var questionId = questionDiv.attr('data-question-id');
+
+    console.log(typeof parseInt(questionId));
+
+    $.ajax({
+        type:'POST',
+        url: '/removeQuestion',
+        data: JSON.stringify({questionId:parseInt(questionId)}),
+        contentType: 'application/json',
+        success: function(data) { questionDiv.remove() },
+        error: displayAjaxError
+    });
+}
+
+function editSurveyTitle() {
+    console.log("Changing survey title is not implemented");
 }
 
 

--- a/public/javascript/admin.js
+++ b/public/javascript/admin.js
@@ -96,10 +96,14 @@ function displaySurvey(results) {
 
             questionDiv.append(answerDiv);
         });
-
         questionsDiv.append(questionDiv);
     });
-    console.log(results);
+
+    var createQuestionButton ='<button type="button"' +
+                              '        class="pure-button pure-button-success pure-button-small"' +
+                              '        data-dropdown="#question-type-dropdown">Create Question' +
+                              '</button>';
+    $("#create-question-button-container").html(createQuestionButton);
 }
 
 /* create the HTML for a new question form - doesn't actually submit anything to the server */
@@ -113,7 +117,7 @@ function createQuestion(type) {
         '     <button type="button" class="remove-answer-button pure-button pure-button-error" onclick="removeAnswer(this);"><i class="fa fa-times"></i></button><br>' +
         '    </div>' +
         '  </div>' +
-        '  <button type="button" class="add-answer-button pure-button pure-button-success pure-button-small" onclick="addAnswer(this);"><i class="fa fa-plus"></i></button>' +
+        '  <button type="button" class="add-answer-button pure-button pure-button-success pure-button-small" style="vertical-align:-7px;" onclick="addAnswer(this);"><i class="fa fa-plus"></i></button>' +
         '  <button type="button" class="pure-button pure-button-primary pure-button-small" onclick="saveQuestion(this);">Save Question</button>' +
         '</div>';
 
@@ -153,7 +157,7 @@ function saveQuestion(el) {
 
 /* update the display of the new question to reflect that it has been stored on the server */
 function updateNewQuestion(questionDiv, serverResponse) {
-    /* for now, just re-request the survey info and display it */
+    // re-request the survey info and display it
     var questionsDiv = $("#survey-questions");
     questionsDiv.empty();
 

--- a/public/javascript/createsurvey.js
+++ b/public/javascript/createsurvey.js
@@ -18,7 +18,6 @@ function addAnswer(el) {
     var target = $(el); // this will be the + button (with name=question-%questionId%)
     var answersDiv = target.siblings(".answers");
     answersDiv.append(answerHtml);
-
 }
 
 function removeQuestion(el) {


### PR DESCRIPTION
Fixes #93.

Introduces the ability to add or remove questions from the `admin.html` page (`?p=admin`).

There is no other fine-grained ability to edit a question yet, only to remove it entirely.
