### PR TITLE
Allow running server and client on different domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ require('./modules/globals');
  * Module dependencies.
  */
 var express = require('express');
+var cors = require('cors');
 var vote = require('./routes/vote');
 var deVote = require('./routes/deVote');
 var getSurveyResults = require('./routes/getSurveyResults');
@@ -29,26 +30,11 @@ app.use(express.methodOverride());
 app.use(express.cookieParser('your secret here'));
 app.use(express.session());
 
-/* CORS middleware */
-/* see: http://stackoverflow.com/questions/7067966/how-to-allow-cors-in-express-nodejs */
-var allowCrossDomain = function(req, res, next) {
-    res.header('Access-Control-Allow-Origin', '*');
-    res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
-    res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-
-    // intercept OPTIONS method
-    if ('OPTIONS' == req.method) {
-      res.send(200);
-    }
-    else {
-      next();
-    }
-};
-app.use(allowCrossDomain);
 
 // artificially add a second of latency to every request :)
 // app.use(function(req,res,next){setTimeout(next,1000)});
 
+app.use(cors());
 app.use(app.router);
 app.use(require('stylus').middleware(__dirname + '/public'));
 app.use(express.static(path.join(__dirname, 'public')));

--- a/index.js
+++ b/index.js
@@ -29,13 +29,29 @@ app.use(express.methodOverride());
 app.use(express.cookieParser('your secret here'));
 app.use(express.session());
 
+/* CORS middleware */
+/* see: http://stackoverflow.com/questions/7067966/how-to-allow-cors-in-express-nodejs */
+var allowCrossDomain = function(req, res, next) {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
+    res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+    // intercept OPTIONS method
+    if ('OPTIONS' == req.method) {
+      res.send(200);
+    }
+    else {
+      next();
+    }
+};
+app.use(allowCrossDomain);
+
 // artificially add a second of latency to every request :)
 // app.use(function(req,res,next){setTimeout(next,1000)});
 
 app.use(app.router);
 app.use(require('stylus').middleware(__dirname + '/public'));
 app.use(express.static(path.join(__dirname, 'public')));
-
 
 
 // development only

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "pg": ">=2.6",
     "winston": ">=0.7.2",
     "q": ">=0.9.7",
-    "db-migrate": ">=0.6.2"
+    "db-migrate": ">=0.6.2",
+    "cors": ">=2.1.0"
   },
   "devDependencies": {
     "mocha": ">=1.13.0",

--- a/public/javascript/admin.js
+++ b/public/javascript/admin.js
@@ -145,7 +145,7 @@ function saveQuestion(el) {
 
     $.ajax({
         type: "POST",
-        url: "/addQuestions",
+        url: AJAX_REQUEST_URL + "/addQuestions",
         data: data,
         contentType: 'application/json',
         success: function(data) {
@@ -179,7 +179,7 @@ function deleteQuestion(el) {
 
     $.ajax({
         type:'POST',
-        url: '/removeQuestion',
+        url: AJAX_REQUEST_URL + '/removeQuestion',
         data: JSON.stringify({questionId:parseInt(questionId)}),
         contentType: 'application/json',
         success: function(data) { questionDiv.remove() },

--- a/public/javascript/admin.js
+++ b/public/javascript/admin.js
@@ -9,7 +9,7 @@ function getSurveyInfo() {
     if (survey) {
         $.ajax({
             type:'GET',
-            url: '/getSurveyInfo',
+            url: AJAX_REQUEST_URL + '/getSurveyInfo',
             data: {surveyId: survey},
             success: displaySurvey,
             error: displayAjaxError

--- a/public/javascript/createsurvey.js
+++ b/public/javascript/createsurvey.js
@@ -73,7 +73,7 @@ $(document).ready(function () {
         var jsonData = JSON.stringify(data);
         $.ajax({
             type: "POST",
-            url: "/createSurvey",
+            url: AJAX_REQUEST_URL + "/createSurvey",
             data: jsonData,
             contentType: 'application/json',
             success: function (data) {

--- a/public/javascript/results.js
+++ b/public/javascript/results.js
@@ -11,7 +11,7 @@ $(function getSurveyInfo() {
     if (survey) {
         $.ajax({
             type:'GET',
-            url: '/getSurveyInfo',
+            url: AJAX_REQUEST_URL + '/getSurveyInfo',
             data: {surveyId: survey},
             success: displaySurveyInfo,
             error: displayAjaxError
@@ -26,7 +26,7 @@ function getSurveyResults() {
     if (survey) {
         $.ajax({
             type:'GET',
-            url: '/getSurveyResults',
+            url: AJAX_REQUEST_URL + '/getSurveyResults',
             data: {surveyId: survey},
             success: displaySurveyResults,
             error: displayAjaxError

--- a/public/javascript/site.js
+++ b/public/javascript/site.js
@@ -1,4 +1,22 @@
+/* GLOBAL CONFIGURATION */
+
+// We need to determine if this client is being served from the local machine or another host
+// If it's serving from localhost, make sure that every Ajax request is sent to this machine
+// If it's being served from somewhere else, make all Ajax requests to dev.isaacdontjelindell.com (for now!)
+var hostname = document.location.hostname;
+
+var AJAX_REQUEST_URL;
+if (window.document.location.port != "") {
+    AJAX_REQUEST_URL = "";
+} else {
+    AJAX_REQUEST_URL = "http://dev.isaacdontjelindell.com:8000";
+}
+
+console.log("port: " + window.document.location.port);
+console.log("url: " + AJAX_REQUEST_URL);
+
 var pageTitle;
+
 
 // usage: $.QueryString["param"]
 (function($) {

--- a/public/javascript/site.js
+++ b/public/javascript/site.js
@@ -3,8 +3,6 @@
 // We need to determine if this client is being served from the local machine or another host
 // If it's serving from localhost, make sure that every Ajax request is sent to this machine
 // If it's being served from somewhere else, make all Ajax requests to dev.isaacdontjelindell.com (for now!)
-var hostname = document.location.hostname;
-
 var AJAX_REQUEST_URL;
 if (window.document.location.port != "") {
     AJAX_REQUEST_URL = "";

--- a/public/javascript/site.js
+++ b/public/javascript/site.js
@@ -10,9 +10,6 @@ if (window.document.location.port != "") {
     AJAX_REQUEST_URL = "http://dev.isaacdontjelindell.com:8000";
 }
 
-console.log("port: " + window.document.location.port);
-console.log("url: " + AJAX_REQUEST_URL);
-
 var pageTitle;
 
 

--- a/public/javascript/takesurvey.js
+++ b/public/javascript/takesurvey.js
@@ -7,7 +7,7 @@ $(function getSurveyInfo() {
     if (survey) {
         $.ajax({
             type:'GET',
-            url: '/getSurveyInfo',
+            url: AJAX_REQUEST_URL + '/getSurveyInfo',
             data: {surveyId: survey},
             success: displaySurvey,
             error: displayAjaxError
@@ -172,7 +172,7 @@ function deVote(questionId, answerId) {
 
     $.ajax({
         type: 'POST',
-        url: '/deVote',
+        url: AJAX_REQUEST_URL + '/deVote',
         data: JSON.stringify(data),
         contentType: "application/json",
         success: showDevoteSuccess,
@@ -202,7 +202,7 @@ function submitVote(questionId, answerId) {
 
     $.ajax({
         type: 'POST',
-        url: '/vote',
+        url: AJAX_REQUEST_URL + '/vote',
         data: JSON.stringify(data),
         contentType: "application/json",
         success: showSubmitSuccess,


### PR DESCRIPTION
I've made changes needed to host the HTML/JS client on a different server/domain than the actual Ajax server is running on.

This required:
- adding CORS middleware so that Express allows requests from a different domain
- Detecting what environment we're running on, and determining what Ajax base url to use. I've set up some GitHub pages hosting for the HTML client, which is accessible at `tapvote.github.io`. (I created the organization TapVote to get that URL - I'll tell you more about it later).

Right now, if the port the client is being served on is 80, it assumes that the Ajax server it should use is `dev.isaacdontjelindell.com:8000`. This would be the case if the client is being hosted on GitHub Pages.

If the port it's using is 8000, the client assumes that it's being hosted on the same machine as the Ajax server, and just uses URLs relative to `localhost:8000`.

This isn't perfect, as it assumes the production client is going be hosted on 80, but I think that's a reasonable assumption for now. 

As the GitHub pages repo I'm using is a totally different repository (so that we could get that nicer URL), pushing changes to it is a manual process right now. (It involves copying the contents of `/public` to the Pages repository, then committing and pushing. I'm going to work on a better automated solution - right now I'm just using a Bash script to do it).

None of this should affect running a local development environment.

I went ahead and pulled this branch down onto the dev server, so the client served from `http://tapvote.github.io` should be working.
