### PR TITLE
revert to github issues until gitreports.com is fixed

### DIFF
--- a/public/footer.html
+++ b/public/footer.html
@@ -7,7 +7,8 @@
     <a href="/?p=results">Show Results</a>
   </span>
   <span id="copyright">Copyright &copy; 2013 TapVote.</span>
-  <a href="http://gitreports.com/issue/LutherSrProject/TapVote" target="_blank">
+  <!--<a href="http://gitreports.com/issue/LutherSrProject/TapVote" target="_blank">-->
+  <a href="https://github.com/LutherSrProject/TapVote/issues/new" target="_blank">
     <button type="button" class="pure-button pure-button-tiny pure-button-secondary">Report An Issue</button>
   </a>
 </div>


### PR DESCRIPTION
EDIT: Don't merge this yet - the issue w/ gitreports may be fixed. Waiting to make sure before closing this PR.

EDIT 2: Okay, the issue is fixed. Canceling this PR. 

I have an issue open with gitreports.com, but until it's fixed, I'm reverting to just linking to a new GitHub issue. It's not perfect, but good enough for now.

Here's the issue I have open with gitreports.
https://github.com/schneidmaster/gitreports.com/issues/10

Gitreports is completely broken right now - I can't even get our project to show up, but the projects from Campus Curb are both showing up!
