### PR TITLE
Implement open vs. closed survey

### DIFF
--- a/migrations/20131215224547-version5.js
+++ b/migrations/20131215224547-version5.js
@@ -1,9 +1,10 @@
 var dbm = require('db-migrate');
+var moment = require('moment');
 var type = dbm.dataType;
 
 exports.up = function(db, callback) {
     var queryString = "ALTER TABLE survey" +
-                      "    ADD COLUMN start timestamp DEFAULT (now() at time zone 'UTC')," +
+                      "    ADD COLUMN start timestamp DEFAULT ('" + moment.utc().format() + "')," +
                       "    ADD COLUMN finish timestamp DEFAULT '2300-01-01';";
 
     db.runSql(queryString, callback);

--- a/migrations/20131215224547-version5.js
+++ b/migrations/20131215224547-version5.js
@@ -1,0 +1,18 @@
+var dbm = require('db-migrate');
+var type = dbm.dataType;
+
+exports.up = function(db, callback) {
+    var queryString = "ALTER TABLE survey" +
+                      "    ADD COLUMN start timestamp DEFAULT (now() at time zone 'UTC')," +
+                      "    ADD COLUMN finish timestamp DEFAULT '2300-01-01';";
+
+    db.runSql(queryString, callback);
+};
+
+exports.down = function(db, callback) {
+    var queryString = "ALTER TABLE survey" +
+                      "    DROP COLUMN start," +
+                      "    DROP COLUMN finish;";
+
+    db.runSql(queryString, callback);
+};

--- a/migrations/20131215224547-version5.js
+++ b/migrations/20131215224547-version5.js
@@ -4,8 +4,8 @@ var type = dbm.dataType;
 
 exports.up = function(db, callback) {
     var queryString = "ALTER TABLE survey" +
-                      "    ADD COLUMN start timestamp DEFAULT ('" + moment.utc().format() + "')," +
-                      "    ADD COLUMN finish timestamp DEFAULT '2300-01-01';";
+                      "    ADD COLUMN start timestamp with time zone DEFAULT ('" + moment.utc().format() + "')," +
+                      "    ADD COLUMN finish timestamp with time zone DEFAULT '2300-01-01z';";
 
     db.runSql(queryString, callback);
 };

--- a/modules/database/createSurvey.js
+++ b/modules/database/createSurvey.js
@@ -9,9 +9,13 @@ var createSurvey = function (surveyData, callback) {
     var questions = surveyData['questions'];
     var password = surveyData['password'];
 
+    var start, finish;
+
     // off-load validation to moment
-    var start = moment.utc(surveyData['start'], 'YYYY-MM-DD HH:mm:ss');
-    var finish = moment.utc(surveyData['finish'], 'YYYY-MM-DD HH:mm:ss');
+    if (surveyData['start'])
+        start = moment.utc(surveyData['start'], 'YYYY-MM-DD HH:mm:ss');
+    if (surveyData['finish'])
+        finish = moment.utc(surveyData['finish'], 'YYYY-MM-DD HH:mm:ss');
 
     var queryString;
     var queryParams;

--- a/modules/database/createSurvey.js
+++ b/modules/database/createSurvey.js
@@ -15,15 +15,15 @@ var createSurvey = function (surveyData, callback) {
     if (start && finish) {
         queryString = 'INSERT INTO survey(title, password, start, finish) VALUES ($1, $2, $3, $4) RETURNING *';
         queryParams = [title, password, start, finish];
-    } else if (!start  && !finish) {
-        queryString = 'INSERT INTO survey(title, password) VALUES ($1, $2) RETURNING *';
-        queryParams = [title, password];
-    } else if (!start) {
+    } else if (!start && finish) {
         queryString = 'INSERT INTO survey(title, password, finish) VALUES ($1, $2, $3) RETURNING *';
         queryParams = [title, password, finish];
-    } else {  // !finish
+    } else if (start && !finish){  // !finish
         queryString = 'INSERT INTO survey(title, password, start) VALUES ($1, $2, $3) RETURNING *';
         queryParams = [title, password, start];
+    } else {  // !start && !finish
+        queryString = 'INSERT INTO survey(title, password) VALUES ($1, $2) RETURNING *';
+        queryParams = [title, password];
     }
 
     logger.info("Inserting new survey into database...");

--- a/modules/database/createSurvey.js
+++ b/modules/database/createSurvey.js
@@ -1,4 +1,5 @@
 var Q = require("q");
+var moment = require("moment");
 var runQuery = require("./runQuery").runQuery;
 var addQuestions = require("./addQuestions").addQuestions;
 
@@ -7,20 +8,22 @@ var createSurvey = function (surveyData, callback) {
     var title = surveyData['title'];
     var questions = surveyData['questions'];
     var password = surveyData['password'];
-    var start = surveyData['start'];
-    var finish = surveyData['finish'];
+
+    // off-load validation to moment
+    var start = moment.utc(surveyData['start'], 'YYYY-MM-DD HH:mm:ss');
+    var finish = moment.utc(surveyData['finish'], 'YYYY-MM-DD HH:mm:ss');
 
     var queryString;
     var queryParams;
     if (start && finish) {
         queryString = 'INSERT INTO survey(title, password, start, finish) VALUES ($1, $2, $3, $4) RETURNING *';
-        queryParams = [title, password, start, finish];
+        queryParams = [title, password, start.format(), finish.format()];
     } else if (!start && finish) {
         queryString = 'INSERT INTO survey(title, password, finish) VALUES ($1, $2, $3) RETURNING *';
-        queryParams = [title, password, finish];
+        queryParams = [title, password, finish.format()];
     } else if (start && !finish){  // !finish
         queryString = 'INSERT INTO survey(title, password, start) VALUES ($1, $2, $3) RETURNING *';
-        queryParams = [title, password, start];
+        queryParams = [title, password, start.format()];
     } else {  // !start && !finish
         queryString = 'INSERT INTO survey(title, password) VALUES ($1, $2) RETURNING *';
         queryParams = [title, password];

--- a/modules/database/createSurvey.js
+++ b/modules/database/createSurvey.js
@@ -7,9 +7,27 @@ var createSurvey = function (surveyData, callback) {
     var title = surveyData['title'];
     var questions = surveyData['questions'];
     var password = surveyData['password'];
+    var start = surveyData['start'];
+    var finish = surveyData['finish'];
+
+    var queryString;
+    var queryParams;
+    if (start && finish) {
+        queryString = 'INSERT INTO survey(title, password, start, finish) VALUES ($1, $2, $3, $4) RETURNING *';
+        queryParams = [title, password, start, finish];
+    } else if (!start  && !finish) {
+        queryString = 'INSERT INTO survey(title, password) VALUES ($1, $2) RETURNING *';
+        queryParams = [title, password];
+    } else if (!start) {
+        queryString = 'INSERT INTO survey(title, password, finish) VALUES ($1, $2, $3) RETURNING *';
+        queryParams = [title, password, finish];
+    } else {  // !finish
+        queryString = 'INSERT INTO survey(title, password, start) VALUES ($1, $2, $3) RETURNING *';
+        queryParams = [title, password, start];
+    }
 
     logger.info("Inserting new survey into database...");
-    runQuery('INSERT INTO survey(title, password) VALUES($1, $2) RETURNING *', [title, password])
+    runQuery(queryString, queryParams)
     .then(function (result) {
         // insert the new survey (return the survey ID to use in inserting questions)
         logger.info("Inserted survey. New survey ID is", result.rows[0].id);

--- a/modules/database/deleteVote.js
+++ b/modules/database/deleteVote.js
@@ -1,20 +1,75 @@
 var Q = require("q");
+var moment = require("moment");
 var runQuery = require("./runQuery").runQuery;
 
 
 var deleteVote = function (data, callback) {
     // data = {"questionId":5, "answerId":3}
 
-    // need to check that data['answerId'] has a questionId == data['questionId']
+    /* need to check that data['answerId'] has a questionId == data['questionId'] */
     runQuery('SELECT "questionId" FROM answer WHERE id=$1', [data['answerId']])
     .then(function (results) {
         var qid = results.rows[0].questionId;
         if(qid == data['questionId']) {
           return;
         } else {
-          throw Error();
+            logger.error("Question doesn't have that answer as an option.");
+            var error = Error();
+            error['httpStatus'] = 400;
+            error['httpResponse'] = '400 Bad Request';
+            error['friendlyName'] = "questionId and answerId don't match";
+            throw error;
         }
     })
+
+    /* need to check that this survey is open (between start and finish datetimes) */
+    .then(function (res) {
+        var queryString, queryParams;
+        if (data['surveyId']) {
+            queryString = 'SELECT * FROM survey WHERE id = $1';
+            queryParams = [data['surveyId']];
+        } else {
+            // if surveyId isn't provided, get it based on the (answerId, questionId) pair.
+            queryString = 'SELECT * FROM survey WHERE id = (SELECT "surveyId" FROM question WHERE id = $1)';
+            queryParams = [data['questionId']];
+        }
+
+        // find the survey info associated w/ this (questionId, answerId) pair.
+        return runQuery(queryString, queryParams)
+        .then(function (survey) {
+            var error;
+            var now = moment.utc();
+
+            // check that now is after start
+            if (survey.rows[0].start) {
+                var start = moment.utc(survey.rows[0].start);
+                if (now.isBefore(start)) { // survey isn't open yet
+                    logger.warn("Survey isn't yet open. Start time is " + start.format());
+                    error = new Error();
+                }
+            }
+            // check that now is before finish
+            if (survey.rows[0].finish) {
+                var finish = moment.utc(survey.rows[0].finish);
+                if (now.isAfter(finish)) { // survey is already closed
+                    logger.warn("Survey is already closed. Finish time was " + finish.format());
+                    error = new Error()
+                }
+            }
+
+            if (error) {
+                error['httpStatus'] = 400;
+                error['httpResponse'] = '400 Bad Request';
+                error['friendlyName'] = 'Survey is not open';
+                throw error;
+            }
+        })
+        .fail(function (error) {
+            // propagate errors up the chain
+            throw error;
+        });
+    })
+    /* if previous conditions have been met, delete the vote */
     .then(function (results) {
         // This query is needed because Postgres doesn't support LIMIT in DELETE queries.
         // Here we're relying on the ctid column, which is the physical location of the row. It's not
@@ -22,23 +77,15 @@ var deleteVote = function (data, callback) {
         // See for more info:
         // http://www.postgresql.org/message-id/07f0833692070125b9317094e7008b4f@biglumber.com
         var queryString = 'DELETE FROM vote WHERE ctid = (SELECT ctid FROM vote WHERE "questionId"=$1 AND "answerId"=$2 LIMIT 1)';
-        runQuery(queryString, [data['questionId'], data['answerId']])
+        return runQuery(queryString, [data['questionId'], data['answerId']])
         .then(function (res) {
             logger.info("Query success: deleted vote from database");
             callback(null, res);
             return;
         })
-        .fail(function (error) {
-            logger.error("Query fail: error deleting vote from database");
-            callback(error);
-            return;
-        })
     })
     .fail(function (error) {
-        logger.error("Question doesn't have that answer as an option.", error);
-        error['httpStatus'] = 400;
-        error['httpResponse'] = '400 Bad Request';
-        error['friendlyName'] = "questionId and answerId don't match";
+        logger.error("Failed to delete the vote from the database. ", error);
         callback(error);
         return;
     });

--- a/modules/database/recordVote.js
+++ b/modules/database/recordVote.js
@@ -13,7 +13,7 @@ var recordVote = function (voteData, callback) {
         if (qid == voteData['questionId']) {
             return;
         } else {
-            logger.error("Question doesn't have that answer as an option.", error);
+            logger.error("Question doesn't have that answer as an option.");
             var error = Error();
             error['httpStatus'] = 400;
             error['httpResponse'] = '400 Bad Request';
@@ -33,7 +33,7 @@ var recordVote = function (voteData, callback) {
             queryParams = [voteData['questionId']];
         }
 
-        // find the survey info associated w/ this (questionId, answerId pair).
+        // find the survey info associated w/ this (questionId, answerId).
         return runQuery(queryString, queryParams)
         .then(function (survey) {
             var error;
@@ -78,7 +78,7 @@ var recordVote = function (voteData, callback) {
         })
     })
     .fail(function (error) {
-        logger.error("Error logging vote to database.", error);
+        logger.error("Error logging vote to database. ", error);
         callback(error);
         return;
     });

--- a/modules/database/recordVote.js
+++ b/modules/database/recordVote.js
@@ -1,38 +1,84 @@
 var Q = require("q");
+var moment = require("moment");
 var runQuery = require("./runQuery").runQuery;
 
 
 var recordVote = function (voteData, callback) {
     // voteData = {'answerId':5, 'questionId':5}
 
-    // need to check that voteData['answerId'] has a questionId == voteData['questionId']
+    /* need to check that voteData['answerId'] has a questionId == voteData['questionId'] */
     runQuery('SELECT "questionId" FROM answer WHERE id=$1', [voteData['answerId']])
     .then(function (results) {
         var qid = results.rows[0].questionId;
-        if(qid == voteData['questionId']) {
-          return;
+        if (qid == voteData['questionId']) {
+            return;
         } else {
-          throw Error();
+            logger.error("Question doesn't have that answer as an option.", error);
+            var error = Error();
+            error['httpStatus'] = 400;
+            error['httpResponse'] = '400 Bad Request';
+            error['friendlyName'] = "questionId and answerId don't match";
+            throw error;
         }
     })
-    .then(function (results) {
-        runQuery('INSERT INTO vote("answerId", "questionId") VALUES($1, $2)', [voteData['answerId'], voteData['questionId']])
+    /* need to check that this survey is open (between start and finish datetimes) */
+    .then(function (res) {
+        var queryString, queryParams;
+        if (voteData['surveyId']) {
+            queryString = 'SELECT * FROM survey WHERE id = $1';
+            queryParams = [voteData['surveyId']];
+        } else {
+            // if surveyId isn't provided, get it based on the (answerId, questionId) pair.
+            queryString = 'SELECT * FROM survey WHERE id = (SELECT "surveyId" FROM question WHERE id = $1)';
+            queryParams = [voteData['questionId']];
+        }
+
+        // find the survey info associated w/ this (questionId, answerId pair).
+        return runQuery(queryString, queryParams)
+        .then(function (survey) {
+            var error;
+            var now = moment.utc();
+
+            // check that now is after start
+            if (survey.rows[0].start) {
+                var start = moment.utc(survey.rows[0].start);
+                if (now.isBefore(start)) { // survey isn't open yet
+                    logger.warn("Survey isn't yet open. Start time is " + start.format());
+                    error = new Error();
+                }
+            }
+            // check that now is before finish
+            if (survey.rows[0].finish) {
+                var finish = moment.utc(survey.rows[0].finish);
+                if (now.isAfter(finish)) { // survey is already closed
+                    logger.warn("Survey is already closed. Finish time was " + finish.format());
+                    error = new Error()
+                }
+            }
+
+            if (error) {
+                error['httpStatus'] = 400;
+                error['httpResponse'] = '400 Bad Request';
+                error['friendlyName'] = 'Survey is not open';
+                throw error;
+            }
+        })
+        .fail(function (error) {
+            // propagate errors up the chain
+            throw error;
+        });
+    })
+    /* if previous conditions have been met, insert the vote */
+    .then(function (res) {
+        return runQuery('INSERT INTO vote("answerId", "questionId") VALUES($1, $2)', [voteData['answerId'], voteData['questionId']])
         .then(function (results) {
                 logger.info("Recorded vote in database.");
                 callback(null, results);
                 return;
         })
-        .fail(function (error) {
-                logger.error("Error logging vote to database.", error);
-                callback(error);
-                return;
-        });
     })
     .fail(function (error) {
-        logger.error("Question doesn't have that answer as an option.", error);
-        error['httpStatus'] = 400;
-        error['httpResponse'] = '400 Bad Request';
-        error['friendlyName'] = "questionId and answerId don't match";
+        logger.error("Error logging vote to database.", error);
         callback(error);
         return;
     });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "winston": ">=0.7.2",
     "q": ">=0.9.7",
     "db-migrate": ">=0.6.2",
-    "cors": ">=2.1.0"
+    "cors": ">=2.1.0",
+    "moment": ">=2.4.0"
   },
   "devDependencies": {
     "mocha": ">=1.13.0",

--- a/routes/createSurvey.js
+++ b/routes/createSurvey.js
@@ -4,7 +4,8 @@ var endpoint = require("../modules/endpoint");
 var questionsObjectValidator = require("../modules/validators/questionsObjectValidator");
 
 //Test this endpoint with
-//curl -d '{ "title":"\"Because clickers are SO 1999.\"", "questions": [{"question": "Which is best?", "type":"MCSR", "answers": ["Puppies", "Cheese", "Joss Whedon", "Naps"]}],"password":"supersecretpassword" }' -H "Content-Type: application/json" http://localhost:8000/createSurvey
+// curl -d '{ "title":"\"Because clickers are SO 1999.\"", "questions": [{"question": "Which is best?", "type":"MCSR", "answers": ["Puppies", "Cheese", "Joss Whedon", "Naps"]}],"password":"supersecretpassword", "start":"1993-04-10", "finish":"2013-12-30" }' -H "Content-Type: application/json" http://localhost:8000/createSurvey
+
 
 function createSurvey(){
     var apiOptions = {};
@@ -19,7 +20,9 @@ function createSurvey(){
     };
     //Indicates the optional API parameters and their basic expected types.
     apiOptions.optionalApiParameters = {
-            "questions":"object"
+            "questions":"object",
+            "start": "string",
+            "finish": "string"
     };
     
     //Provides additional validation functions after the basic check on required parameters. 

--- a/routes/deVote.js
+++ b/routes/deVote.js
@@ -2,6 +2,9 @@ var database = require("../modules/database");
 var httpresponses = require("../modules/httpresponses");
 var endpoint = require("../modules/endpoint");
 
+// Test this endpoint with
+// curl -d '{"answerId":5, "questionId":5}' -H "Content-Type: application/json" http://localhost:8000/deVote
+
 function deVote(){
     var apiOptions = {};
     


### PR DESCRIPTION
Fixes #84.
Fixes #85.

This adds two optional params to the `/createSurvey` endpoint, `start` and `finish`. Both should be string representations of a UTC timestamp (i.e. `1999-01-08 04:05:06z`) - the `z` is shorthand for zulu/UTC time.

Default for `start` if not provided is the current time. Default for `finish` if not provided is Jan 1, 2300 (just an arbitrary value way in the future).

I'm using a library I've used before to handle the time manipulations (moment.js). Time and date work is such a pain that it makes way more sense to offload that work to a dedicated library. You will need to run `npm install` to get the new package.

Obviously, this also required updates to the database methods, and a modification of the DB schema. You will need to run `node_modules/.bin/db-migrate up` to apply the new schema. 

All times are stored in the DB and manipulated on the server in UTC. Best practice is to do all such calculations in UTC, and rely on client-side code to display times in the user's local time zone. (The client is also responsible for converting the start and finish times it sends to /createSurvey into UTC).

This will also enforce start and finish for the /vote and /deVote endpoints. If the current time isn't between start and finish, those endpoints will return an appropriate error message. 
