### PR TITLE
Implement /addAnswers endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var getSurveyInfo = require('./routes/getSurveyInfo');
 var createSurvey = require('./routes/createSurvey');
 var addQuestions = require('./routes/addQuestions');
 var removeQuestion = require('./routes/removeQuestion');
+var addAnswers = require('./routes/addAnswers');
 var http = require('http');
 var path = require('path');
 
@@ -50,6 +51,7 @@ app.post('/deVote', deVote.deVote());
 app.post('/createSurvey', createSurvey.createSurvey());
 app.post('/addQuestions', addQuestions.addQuestions());
 app.post('/removeQuestion', removeQuestion.removeQuestion());
+app.post('/addAnswers', addAnswers.addAnswers());
 app.get('/getSurveyResults', getSurveyResults.getSurveyResults());
 app.get('/getSurveyInfo', getSurveyInfo.getSurveyInfo());
 

--- a/modules/database.js
+++ b/modules/database.js
@@ -10,6 +10,7 @@ exports.recordVote = require("./database/recordVote").recordVote;
 exports.deleteVote = require("./database/deleteVote").deleteVote;
 exports.removeQuestion = require("./database/removeQuestion").removeQuestion;
 exports.addQuestions = require("./database/addQuestions").addQuestions;
+exports.addAnswers = require("./database/addAnswers").addAnswers;
 
 
 

--- a/modules/database/addAnswers.js
+++ b/modules/database/addAnswers.js
@@ -14,6 +14,13 @@ var addAnswers = function(data, callback) {
         var questionId = answer["questionId"];
 
         return runQuery("INSERT INTO answer(\"questionId\", value) VALUES($1, $2) RETURNING *", [questionId, value])
+        .fail(function (error) {
+            error['friendlyName'] = "Tried to add answer for non-existent questionId";
+            error['httpStatus'] = 400;
+            error['httpResponse'] = "404 Not Found";
+            throw error;
+        })
+        .thenResolve();
     }))
     .then(function (results) {
         callback(null); // status success

--- a/modules/database/addAnswers.js
+++ b/modules/database/addAnswers.js
@@ -2,7 +2,7 @@ var Q = require("q");
 var runQuery = require("./runQuery").runQuery;
 
 /*
-data = {"answers": [{"questionId":2, "value":"apples"}]}
+curl -d {"answers": [{"questionId":2, "value":"apples"}]} -H "Content-Type:application/json" http://localhost:8000/addAnswers
  */
 
 

--- a/modules/database/addAnswers.js
+++ b/modules/database/addAnswers.js
@@ -1,0 +1,26 @@
+var Q = require("q");
+var runQuery = require("./runQuery").runQuery;
+
+/*
+data = {"answers": [{"questionId":2, "value":"apples"}]}
+ */
+
+
+var addAnswers = function(data, callback) {
+    var answers = data['answers'];
+
+    Q.all(answers.map(function (answer) {
+        var value = answer["value"];
+        var questionId = answer["questionId"];
+
+        return runQuery("INSERT INTO answer(\"questionId\", value) VALUES($1, $2) RETURNING *", [questionId, value])
+    }))
+    .then(function (results) {
+        callback(null); // status success
+    })
+    .fail(function (error) {
+        callback(error);
+    });
+};
+
+exports.addAnswers = addAnswers;

--- a/routes/addAnswers.js
+++ b/routes/addAnswers.js
@@ -42,7 +42,7 @@ function addAnswers(){
                 }
 
                 if (!err["friendlyName"]) {
-                    err["friendlyName"] = "Error adding answers";
+                    err["friendlyName"] = "Error adding new answers";
                 }
                 httpresponses.errorResponse(err, response);
                 return;

--- a/routes/addAnswers.js
+++ b/routes/addAnswers.js
@@ -1,0 +1,64 @@
+var database = require("../modules/database");
+var httpresponses = require("../modules/httpresponses");
+var endpoint = require("../modules/endpoint");
+var questionsObjectValidator = require("../modules/validators/questionsObjectValidator");
+
+//Test this endpoint with
+//curl -d '{"answers": [{"questionId":2, "value":"apples"}]}' -H "Content-Type: application/json" http://localhost:8000/addAnswers
+
+function addAnswers(){
+    var apiOptions = {};
+    
+    //The name of this route:
+    apiOptions.endpointName = "addAnswers";
+    
+    //Indicates the required API parameters and their basic expected types.
+    apiOptions.requiredApiParameters = {
+            "answers":"object"
+    };
+    //Indicates the optional API parameters and their basic expected types.
+    apiOptions.optionalApiParameters = {
+            "surveyId":"number"
+    };
+    
+    //Provides additional validation functions after the basic check on required parameters. 
+    //If a parameter is listed in this object, it MUST validate successfully and return true if provided in the request.
+    //In the case of a problem, return false or throw an error.
+    apiOptions.validators = {
+    };
+    
+    //Function to execute if validation tests are successful.
+    apiOptions.conclusion = function(data, response) {
+        logger.info("Adding new answers.");
+        console.log(data);
+        database.addAnswers(data, function(err, results) {
+            if (err) {
+                if (!err["httpStatus"]) {
+                    err["httpStatus"] = 500;
+                }
+
+                if(!err["httpResponse"]) {
+                    err["httpResponse"] = "500 Internal Server Error";
+                }
+
+                if (!err["friendlyName"]) {
+                    err["friendlyName"] = "Error adding answers";
+                }
+                httpresponses.errorResponse(err, response);
+                return;
+            }
+            else {
+                logger.info("Added new answers to database");
+                httpresponses.successResponse(response, results);
+                return;
+            }
+        });
+    };
+    
+    var endpointObject = new endpoint.Endpoint(apiOptions);
+    return function() {  
+        (endpointObject.handle).apply(endpointObject, arguments);  
+    }; //return the handler function for the endpoint
+}
+
+exports.addAnswers = addAnswers;

--- a/tests/db-addAnswers.js
+++ b/tests/db-addAnswers.js
@@ -1,0 +1,38 @@
+var Q = require("q");
+var should = require('should');
+var database = require('../modules/database');
+
+describe("addAnswers", function(){
+    it("inserts a new answer into the database for an already existing question", function(done) {
+        database.addAnswers({"answers": [{"questionId":1, "value":"new answer"}]}, function(err,results) {
+            try {
+                should.not.exist(err);
+                done();
+            } catch(testerror) {
+                done(testerror);
+            }
+        });
+    });
+    it("inserts two new answers into the database for an already existing question", function(done) {
+        database.addAnswers({"answers": [{"questionId":1, "value":"new answer"}, {"questionId":1, "value":"new answer 2"}]}, function(err,results) {
+            try {
+                should.not.exist(err);
+                done();
+            } catch(testerror) {
+                done(testerror);
+            }
+        });
+    });
+    it("tries to insert an answer into the database for a non-existent question", function(done) {
+        database.addAnswers({"answers": [{"questionId":0, "value":"new answer"}]}, function(err,results) {
+            try {
+                should.exist(err, "expected to receive an error");
+                done();
+            } catch(testerror) {
+                done(testerror);
+            }
+        });
+    });
+
+});
+

--- a/tests/db-getSurveyInfo.js
+++ b/tests/db-getSurveyInfo.js
@@ -27,6 +27,10 @@ describe("getSurveyInfo", function(){
                 question["answers"][0]["questionId"].should.eql(1);
                 question["answers"][0]["value"].should.eql("red");
 
+                question["answers"][1]["id"].should.eql(1);
+                question["answers"][1]["questionId"].should.eql(1);
+                question["answers"][1]["value"].should.eql("green");
+
                 //results["questions"][0].should.eql({"id":1,"surveyId":1,"value":"What is your favorite color?","type": "MCSR","answers":[{"id":1,"questionId":1,"value":"red"},{"id":2,"questionId":1,"value":"green"},{"id":3,"questionId":1,"value":"blue"},{"id":4,"questionId":1,"value":"orange"}]});
 
                 done();

--- a/tests/db-getSurveyInfo.js
+++ b/tests/db-getSurveyInfo.js
@@ -14,7 +14,20 @@ describe("getSurveyInfo", function(){
                 results['title'].should.eql("A sweet survey");
                 results["questions"].should.be.type("object");
                 results["questions"].length.should.not.be.below(1);
-                results["questions"][0].should.eql({"id":1,"surveyId":1,"value":"What is your favorite color?","type": "MCSR","answers":[{"id":1,"questionId":1,"value":"red"},{"id":2,"questionId":1,"value":"green"},{"id":3,"questionId":1,"value":"blue"},{"id":4,"questionId":1,"value":"orange"}]});
+
+                // do some basic sanity checks on the first question in the survey
+                var question = results["questions"][0];
+
+                question["id"].should.eql(1);
+                question["surveyId"].should.eql(1);
+                question["value"].should.eql("What is your favorite color?");
+                question["type"].should.eql("MCSR");
+
+                question["answers"][0]["id"].should.eql(1);
+                question["answers"][0]["questionId"].should.eql(1);
+                question["answers"][0]["value"].should.eql("red");
+
+                //results["questions"][0].should.eql({"id":1,"surveyId":1,"value":"What is your favorite color?","type": "MCSR","answers":[{"id":1,"questionId":1,"value":"red"},{"id":2,"questionId":1,"value":"green"},{"id":3,"questionId":1,"value":"blue"},{"id":4,"questionId":1,"value":"orange"}]});
 
                 done();
             } catch(testerror) {

--- a/tests/db-recordVote.js
+++ b/tests/db-recordVote.js
@@ -16,6 +16,7 @@ describe("recordVote", function () {
             }
         });
     });
+    // TODO rewrite this test so that it tests an existant answerId that does not belong to the existant questionId
     it("inserts an invalid vote into the database", function(done) {
         database.recordVote({'answerId':0,'questionId':1},function(err,results) {
             try {

--- a/tests/db-recordVote.js
+++ b/tests/db-recordVote.js
@@ -17,7 +17,7 @@ describe("recordVote", function () {
         });
     });
     it("inserts an invalid vote into the database", function(done) {
-        database.recordVote({'answerId':5,'questionId':1},function(err,results) {
+        database.recordVote({'answerId':0,'questionId':1},function(err,results) {
             try {
                 should.exist(err,"expected to receive an error");
                 done();


### PR DESCRIPTION
This includes DB method and API endpoint for `/addAnswers`

`/addAnswers` takes data in the form `{"answers": [{"questionId":2, "value":"apples"}]}`

This also updates some unit tests to be more repeatable (i.e. not directly compare survey objects, when the survey may have more answers than is being tested for due to the actions of a previous unit test.)

Fixes #172.
