### PR TITLE
Unit Testing Sanity

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,21 @@ $ sudo apt-get install postgresql
 ```
 
 Connect to the newly installed Postgres server using the default `postgres` database. We will set a password and
-create the test database. When prompted for a new password, use `wearetapvote`.
+create the development and test databases. When prompted for a new password, use `wearetapvote`.
 ```
 $ sudo -u postgres psql postgres
 # \password postgres
+# create database tapvote;
 # create database tapvotetest;
 <Ctrl>-D
 ```
 
-Now set up the schema (run this command from the TapVote repository directory):
+Now set up the schema for the development database (run this command from the TapVote repository directory):
 ```
 $ node_modules/.bin/db-migrate up
 ```
+
+(Note that the schema for the unit-testing database (tapvotetest) will be created as needed by the unit test suite.)
 
 If everything worked, you should be able to start the server by running:
 ```

--- a/database.json
+++ b/database.json
@@ -1,1 +1,0 @@
-{ "dev": "postgres://postgres:wearetapvote@localhost/tapvotetest" }

--- a/database.json
+++ b/database.json
@@ -1,0 +1,4 @@
+{
+    "dev": "postgres://postgres:wearetapvote@localhost/tapvote",
+    "test": "postgres://postgres:wearetapvote@localhost/tapvotetest"
+}

--- a/modules/database-test.js
+++ b/modules/database-test.js
@@ -3,15 +3,7 @@
  * each individual database module.
  */
 
-// this should be used anytime we need to connect to the DB
-var dbPassword = process.env.TAPVOTE_DATABASE_PASSWORD;
-
-// if it's set in the environment, use that password. Otherwise, use "wearetapvote"
-if (dbPassword)
-    CONNSTRING = "postgres://postgres:" + dbPassword + "@localhost/tapvote";
-else
-    CONNSTRING = "postgres://postgres:wearetapvote@localhost/tapvote";
-
+CONNSTRING = "postgres://postgres:wearetapvote@localhost/tapvotetest";
 
 exports.addQuestions = require("./database/addQuestions").addQuestions;
 exports.createSurvey = require("./database/createSurvey").createSurvey;

--- a/modules/database/runQuery.js
+++ b/modules/database/runQuery.js
@@ -2,17 +2,6 @@ var Q = require("q");
 var pg = require("pg"); // PostgreSQL client library
 
 
-// this should be used anytime we need to connect to the DB
-var CONNSTRING;
-var dbPassword = process.env.TAPVOTE_DATABASE_PASSWORD;
-
-// if it's set in the environment, use that password. Otherwise, use "wearetapvote"
-if (dbPassword)
-    CONNSTRING = "postgres://postgres:" + dbPassword + "@localhost/tapvotetest";
-else
-    CONNSTRING = "postgres://postgres:wearetapvote@localhost/tapvotetest";
-
-
 var runQuery = function (queryString, values) {
     var deferred = Q.defer();
     pg.connect(CONNSTRING, function (err, client, done) {
@@ -38,6 +27,5 @@ var runQuery = function (queryString, values) {
     });
     return deferred.promise;
 };
-
 
 exports.runQuery = runQuery;

--- a/tests/00-setup.js
+++ b/tests/00-setup.js
@@ -1,9 +1,10 @@
-beforeEach(function (done) {
-    console.log(" ###### BEFORE TEST ");
-    done();
-});
 
-afterEach(function (done) {
-    console.log(" ###### AFTER TEST");
-    done();
+var sys = require('sys');
+var exec = require('child_process').exec;
+
+beforeEach(function (done) {
+    // reset the contents of the database
+    exec("db-migrate down 20131029 -e test && db-migrate up -e test", function (error, stdout, stderr) {
+        done();
+    });
 });

--- a/tests/00-setup.js
+++ b/tests/00-setup.js
@@ -1,0 +1,9 @@
+beforeEach(function (done) {
+    console.log(" ###### BEFORE TEST ");
+    done();
+});
+
+afterEach(function (done) {
+    console.log(" ###### AFTER TEST");
+    done();
+});

--- a/tests/00-setup.js
+++ b/tests/00-setup.js
@@ -4,7 +4,11 @@ var exec = require('child_process').exec;
 
 beforeEach(function (done) {
     // reset the contents of the database
-    exec("db-migrate down 20131029 -e test && db-migrate up -e test", function (error, stdout, stderr) {
+    var command = "db-migrate down 20131029 -e test && " +
+                  "db-migrate up -e test";
+    exec(command, function (error, stdout, stderr) {
+        if (stderr)
+            console.log(stderr);
         done();
     });
 });

--- a/tests/db-addAnswer.js
+++ b/tests/db-addAnswer.js
@@ -1,6 +1,6 @@
 var Q = require("q");
 var should = require('should');
-var database = require('../modules/database');
+var database = require('../modules/database-test');
 
 describe("addAnswer", function(){
     it("inserts a new answer into the database for an already existing question", function(done) {

--- a/tests/db-addAnswer.js
+++ b/tests/db-addAnswer.js
@@ -1,6 +1,10 @@
+//Attach global variables
+require('../modules/globals');
+
 var Q = require("q");
 var should = require('should');
 var database = require('../modules/database-test');
+
 
 describe("addAnswer", function(){
     it("inserts a new answer into the database for an already existing question", function(done) {
@@ -14,7 +18,7 @@ describe("addAnswer", function(){
         });
     });
     it("tries to insert an answer into the database for a non-existent question", function(done) {
-        database.addAnswer({"questionId":0, "value":"new answer"}, function(err,results) {
+        database.addAnswer({"questionId":2, "value":"new answer"}, function(err,results) {
             try {
                 should.exist(err, "expected to receive an error");
                 done();

--- a/tests/db-addQuestions.js
+++ b/tests/db-addQuestions.js
@@ -26,25 +26,5 @@ describe("addQuestions", function(){
             }
         });
     });
-    it.skip("inserts questions and answers into the database for a survey that has no questions into the database", function(done) {
-        database.addQuestions({ "surveyId":1, "questions": [{"question": "Question 1", "type":"MCSR", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]}],"password":"supersecretpassword" },function(err,results) {
-            try {
-                should.not.exist(err);
-                done();
-            } catch(testerror) {
-                done(testerror);
-            }
-        });
-    });
-    it.skip("inserts two questions and answers into the database for a survey that has no questions into the database", function(done) {
-        database.addQuestions({ "surveyId":1, "questions": [{"question": "Question 1", "type":"MCSR", "answers": ["Q1a1", "Q1a2", "Q1a3", "Q1a4"]}],"password":"supersecretpassword" },function(err,results) {
-            try {
-                should.not.exist(err);
-                done();
-            } catch(testerror) {
-                done(testerror);
-            }
-        });
-    });
 });
 

--- a/tests/db-addQuestions.js
+++ b/tests/db-addQuestions.js
@@ -1,6 +1,6 @@
 var Q = require("q");
 var should = require('should');
-var database = require('../modules/database');
+var database = require('../modules/database-test');
 
 describe("addQuestions", function(){
     it("inserts questions and answers into the database for a survey that already has questions into the database", function(done) {

--- a/tests/db-addQuestions.js
+++ b/tests/db-addQuestions.js
@@ -1,3 +1,6 @@
+//Attach global variables
+require('../modules/globals');
+
 var Q = require("q");
 var should = require('should');
 var database = require('../modules/database-test');

--- a/tests/db-createSurvey.js
+++ b/tests/db-createSurvey.js
@@ -3,7 +3,7 @@ require('../modules/globals');
 
 var Q = require("q");
 var should = require('should');
-var database = require('../modules/database');
+var database = require('../modules/database-test');
 
 
 describe("createSurvey", function () {

--- a/tests/db-deleteVote.js
+++ b/tests/db-deleteVote.js
@@ -1,6 +1,6 @@
 var Q = require("q");
 var should = require('should');
-var database = require('../modules/database');
+var database = require('../modules/database-test');
 
 describe("deleteVote", function () {
     it("deletes a valid vote from the database", function (done) {

--- a/tests/db-deleteVote.js
+++ b/tests/db-deleteVote.js
@@ -1,3 +1,6 @@
+//Attach global variables
+require('../modules/globals');
+
 var Q = require("q");
 var should = require('should');
 var database = require('../modules/database-test');

--- a/tests/db-getSurveyInfo.js
+++ b/tests/db-getSurveyInfo.js
@@ -18,23 +18,7 @@ describe("getSurveyInfo", function(){
                 results["questions"].should.be.type("object");
                 results["questions"].length.should.not.be.below(1);
 
-                // do some basic sanity checks on the first question in the survey
-                var question = results["questions"][0];
-
-                question["id"].should.eql(1);
-                question["surveyId"].should.eql(1);
-                question["value"].should.eql("What is your favorite color?");
-                question["type"].should.eql("MCSR");
-
-                question["answers"][0]["id"].should.eql(1);
-                question["answers"][0]["questionId"].should.eql(1);
-                question["answers"][0]["value"].should.eql("red");
-
-                question["answers"][1]["id"].should.eql(2);
-                question["answers"][1]["questionId"].should.eql(1);
-                question["answers"][1]["value"].should.eql("green");
-
-                //results["questions"][0].should.eql({"id":1,"surveyId":1,"value":"What is your favorite color?","type": "MCSR","answers":[{"id":1,"questionId":1,"value":"red"},{"id":2,"questionId":1,"value":"green"},{"id":3,"questionId":1,"value":"blue"},{"id":4,"questionId":1,"value":"orange"}]});
+                results["questions"][0].should.eql({"id":1,"surveyId":1,"value":"What is your favorite color?","type": "MCSR","answers":[{"id":1,"questionId":1,"value":"red"},{"id":2,"questionId":1,"value":"green"},{"id":3,"questionId":1,"value":"blue"},{"id":4,"questionId":1,"value":"orange"}]});
 
                 done();
             } catch(testerror) {

--- a/tests/db-getSurveyInfo.js
+++ b/tests/db-getSurveyInfo.js
@@ -1,6 +1,6 @@
 var Q = require("q");
 var should = require('should');
-var database = require('../modules/database');
+var database = require('../modules/database-test');
 
 describe("getSurveyInfo", function(){
     it("gets a valid survey", function(done) {

--- a/tests/db-getSurveyInfo.js
+++ b/tests/db-getSurveyInfo.js
@@ -1,3 +1,6 @@
+//Attach global variables
+require('../modules/globals');
+
 var Q = require("q");
 var should = require('should');
 var database = require('../modules/database-test');

--- a/tests/db-getSurveyResults.js
+++ b/tests/db-getSurveyResults.js
@@ -43,19 +43,19 @@ describe("getSurveyResults", function(){
             var recordVote = Q.denodeify(database.recordVote);
 
             getSurveyResults({'surveyId':1})
-                .then(function(initialResults){
-                          return recordVote({'answerId':2,'questionId':1})
-                              .then(function(){
-                                        return getSurveyResults({'surveyId':1});
-                                    })
-                              .then(function(finalResults){
-                                        (finalResults["2"] - initialResults["2"]).should.eql(1);
-                                        done();
-                                    });
-                      })
-                .fail(function(error) {
-                          done(error);
-                      });
+            .then(function(initialResults){
+                return recordVote({'answerId':2,'questionId':1})
+                .then(function(){
+                    return getSurveyResults({'surveyId':1});
+                })
+                .then(function(finalResults){
+                    (finalResults["2"] - initialResults["2"]).should.eql(1);
+                    done();
+                });
+            })
+            .fail(function(error) {
+                done(error);
+            });
         });
     });
 

--- a/tests/db-getSurveyResults.js
+++ b/tests/db-getSurveyResults.js
@@ -1,6 +1,6 @@
 var Q = require("q");
 var should = require('should');
-var database = require('../modules/database');
+var database = require('../modules/database-test');
 
 
 describe("getSurveyResults", function(){

--- a/tests/db-getSurveyResults.js
+++ b/tests/db-getSurveyResults.js
@@ -1,3 +1,6 @@
+//Attach global variables
+require('../modules/globals');
+
 var Q = require("q");
 var should = require('should');
 var database = require('../modules/database-test');

--- a/tests/db-recordVote.js
+++ b/tests/db-recordVote.js
@@ -1,6 +1,6 @@
 var Q = require("q");
 var should = require('should');
-var database = require('../modules/database');
+var database = require('../modules/database-test');
 
 
 describe("recordVote", function () {

--- a/tests/db-recordVote.js
+++ b/tests/db-recordVote.js
@@ -1,3 +1,6 @@
+//Attach global variables
+require('../modules/globals');
+
 var Q = require("q");
 var should = require('should');
 var database = require('../modules/database-test');


### PR DESCRIPTION
Fixes #174.

This makes some major improvements to the unit testing framework we have.

Part of this is that I've separated dev and testing databases. What this means is that you will have to create a new Postgres database, called `tapvote` (currently, the app is using a database named `tapvotetest`). 

The old `tapvotetest` database will be re-purposed as the new testing database. I did this so that unit tests could modify the database with impunity while still keeping a database w/ usable data in it.

To create the new database (which should probably be done before merging this PR):

```
$ sudo -u postgres psql
# CREATE DATABASE tapvote;
<Ctrl>-D to exit psql
```

I've added a file called `modules/database-test.js`. This does exactly the same thing as `modules/database.js` does, except it uses a different connection string so that it connects to the `tapvotetest` database instead of the `tapvote` database. 
When the database module is `require`d in unit tests, do: 

`var database = require('../modules/database-test')`

instead of the previous:

 `var database = require('../modules/database')`

Note that I've made this change for all unit tests.

The file `test/00-setup.js` defines a function that is run before each unit test. The function calls the `db-migrate` command to drop and recreate the database schema. This allows every unit test to start with a clean slate of database contents. (The only data that will be in the DB is the basic, single-question survey added by one of the db-migrate migrations.)
