### PR TITLE
Initial session support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,17 @@
 //Attach global variables
 require('./modules/globals');
 
+var cookieSecret = process.env.TAPVOTE_COOKIE_SECRET;
+
+if (!cookieSecret) {
+    cookieSecret = 'your secret here';
+}
+
 /**
  * Module dependencies.
  */
 var express = require('express');
+var PGStore = require('connect-pg');
 var cors = require('cors');
 var vote = require('./routes/vote');
 var deVote = require('./routes/deVote');
@@ -15,6 +22,7 @@ var addQuestions = require('./routes/addQuestions');
 var removeQuestion = require('./routes/removeQuestion');
 var addAnswer = require('./routes/addAnswer');
 var removeAnswer = require('./routes/removeAnswer');
+var pgConnect = require('./modules/database').pgConnect;
 var http = require('http');
 var path = require('path');
 
@@ -29,8 +37,8 @@ app.use(express.json()); //express's json request body parser
 app.use(express.urlencoded()); //in the off chance that we use urlencoded requests
 //notably, leaving out file upload support for now
 app.use(express.methodOverride());
-app.use(express.cookieParser('your secret here'));
-app.use(express.session());
+app.use(express.cookieParser(cookieSecret));
+app.use(express.session({store: new PGStore(pgConnect)}));
 
 
 // artificially add a second of latency to every request :)

--- a/modules/database.js
+++ b/modules/database.js
@@ -3,16 +3,32 @@
  * each individual database module.
  */
 
+
 // this should be used anytime we need to connect to the DB
-var dbPassword = process.env.TAPVOTE_DATABASE_PASSWORD;
-
+var dbProtocol = process.env.TAPVOTE_DATABASE_PROTOCOL;
+if (!dbProtocol)
+    dbProtocol = "postgres";
+var dbUser = process.env.TAPVOTE_DATABASE_USER;
+if (!dbUser)
+    dbUser = "postgres";
 // if it's set in the environment, use that password. Otherwise, use "wearetapvote"
-if (dbPassword)
-    CONNSTRING = "postgres://postgres:" + dbPassword + "@localhost/tapvote";
-else
-    CONNSTRING = "postgres://postgres:wearetapvote@localhost/tapvote";
+var dbPassword = process.env.TAPVOTE_DATABASE_PASSWORD;
+if (!dbPassword)
+    dbPassword = "wearetapvote";
+var dbHost = process.env.TAPVOTE_DATABASE_HOST;
+if (!dbHost)
+    dbHost = "localhost";
+var dbDatabase = process.env.TAPVOTE_DATABASE_DATABASE;
+if (!dbDatabase)
+    dbDatabase = "tapvote";
 
+CONNSTRING = dbProtocol + "://" + dbUser + ":" + dbPassword + "@" + dbHost + "/" + dbDatabase;
 
+exports.dbProtocol = dbProtocol;
+exports.dbUser = dbUser;
+exports.dbPassword = dbPassword;
+exports.dbHost = dbHost;
+exports.dbDatabase = dbDatabase;
 exports.addQuestions = require("./database/addQuestions").addQuestions;
 exports.createSurvey = require("./database/createSurvey").createSurvey;
 exports.getSurveyInfo = require("./database/getSurveyInfo").getSurveyInfo;

--- a/modules/database.js
+++ b/modules/database.js
@@ -23,7 +23,7 @@ exports.removeQuestion = require("./database/removeQuestion").removeQuestion;
 exports.addQuestions = require("./database/addQuestions").addQuestions;
 exports.addAnswer = require("./database/addAnswer").addAnswer;
 exports.removeAnswer = require("./database/removeAnswer").removeAnswer;
-
+exports.pgConnect = require("./database/pgConnect").pgConnect;
 
 
 

--- a/modules/database/pgConnect.js
+++ b/modules/database/pgConnect.js
@@ -1,0 +1,16 @@
+var pg = require("pg"); // PostgreSQL client library
+
+function pgConnect (callback) {
+    pg.connect(CONNSTRING,
+        function (err, client, done) {
+            if (err) {
+                console.log(JSON.stringify(err));
+            }
+            if (client) {
+                callback(client);
+                done();
+            }
+        }
+    );
+};
+exports.pgConnect = pgConnect;

--- a/modules/database/pgConnect.js
+++ b/modules/database/pgConnect.js
@@ -1,7 +1,26 @@
 var pg = require("pg"); // PostgreSQL client library
+var database = require("../database");
+
+var dbSessionProtocol = process.env.TAPVOTE_DATABASE_SESSION_PROTOCOL;
+if (!dbSessionProtocol)
+    dbSessionProtocol = database.dbProtocol;
+var dbSessionUser = process.env.TAPVOTE_DATABASE_SESSION_USER; //suggested: nodepg
+if (!dbSessionUser)
+    dbSessionUser = database.dbUser;
+var dbSessionPassword = process.env.TAPVOTE_DATABASE_SESSION_PASSWORD;
+if (!dbSessionPassword)
+    dbSessionPassword = database.dbPassword;
+var dbSessionHost = process.env.TAPVOTE_DATABASE_SESSION_HOST;
+if (!dbSessionHost)
+    dbSessionHost = database.dbHost;
+var dbSessionDatabase = process.env.TAPVOTE_DATABASE_SESSION_DATABASE;
+if (!dbSessionDatabase)
+    dbSessionDatabase = database.dbDatabase;
+
+var sessionConnString = dbSessionProtocol + "://" + dbSessionUser + ":" + dbSessionPassword + "@" + dbSessionHost + "/" + dbSessionDatabase;
 
 function pgConnect (callback) {
-    pg.connect(CONNSTRING,
+    pg.connect(sessionConnString,
         function (err, client, done) {
             if (err) {
                 console.log(JSON.stringify(err));

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "q": ">=0.9.7",
     "db-migrate": ">=0.6.2",
     "cors": ">=2.1.0",
-    "moment": ">=2.4.0"
+    "moment": ">=2.4.0",
+    "connect-pg": ">=1.1.5"
   },
   "devDependencies": {
     "mocha": ">=1.13.0",


### PR DESCRIPTION
This pull request adds the basic framework for using sessions, laying the groundwork for #86.

To get it working, do the following:

(Steps created by following the steps here:
https://github.com/jebas/connect-pg )

sudo apt-get install pgtap
npm install
sudo -u postgres psql -d tapvote -f ./node_modules/connect-pg/lib/session_install.sql
sudo -u postgres psql -d tapvote
CREATE EXTENSION pgtap;
select correct_web();

To change nodepg's password:
alter user nodepg with password 'wearetapvote'

Recommend using environmental vars TAPVOTE_DATABASE_SESSION_USER and TAPVOTE_DATABASE_SESSION_PASSWORD to use the nodepg account, which has minimal permissions.
