### PR TITLE
Refactor results page

### DIFF
--- a/www/javascript/results.js
+++ b/www/javascript/results.js
@@ -18,6 +18,9 @@ function getSurveyInfo() {
             success: getSurveyResults,
             error: displayAjaxError
         });
+
+        setTimeout(getSurveyInfo, 2000);
+
     } else {
         askForSurveyId();
     }
@@ -83,6 +86,7 @@ function displaySurvey(surveyInfo) {
     console.log(surveyInfo);
 
     var titleDiv = $("#survey-title");
+    titleDiv.empty(); // TODO this is just a temporary hack until d3 gets in...
 
     var el = $("<div></div>");
     el.text(surveyInfo['title']);
@@ -91,6 +95,9 @@ function displaySurvey(surveyInfo) {
 
     var questionsDiv = $("#survey-questions");
     questionsDiv.addClass("questions");
+
+    questionsDiv.empty();  // TODO this is just a temporary hack until d3 gets in...
+
     var questions = surveyInfo['questions'];
     $.each(questions, function (index, question) {
         // create a div for each question in questions

--- a/www/javascript/results.js
+++ b/www/javascript/results.js
@@ -6,7 +6,9 @@
 pageTitle = "Results";
 
 
-$(function getSurveyInfo() {
+$(getSurveyInfo());
+
+function getSurveyInfo() {
     var survey = $.QueryString['survey'];
     if (survey) {
         $.ajax({
@@ -19,7 +21,7 @@ $(function getSurveyInfo() {
     } else {
         askForSurveyId();
     }
-});
+}
 
 function getSurveyResults(surveyInfo) {
     var survey = $.QueryString['survey'];


### PR DESCRIPTION
Refactor the results page to update survey info and survey results simultaneously. This fixes the issue that when answers are added to or removed from a question and the results page isn't updated.

I understand that removing everything and rebuilding it isn't the correct solution. However, this will be solved by letting D3 handle that stuff (in a pull request soon-to-be-forthcoming from Sarah :)).
