### PR TITLE
Session init middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ var addAnswer = require('./routes/addAnswer');
 var removeAnswer = require('./routes/removeAnswer');
 var dbConnSetup = require('./modules/database/dbConnSetup');
 var pgConnectSession = dbConnSetup.pgConnectSession;
+var initSession = require('./modules/initsession');
 var http = require('http');
 var path = require('path');
 
@@ -52,6 +53,7 @@ var corsOptions = {
 };
 app.use(cors(corsOptions));
 
+app.use(initSession.initSession);
 app.use(app.router);
 app.use(require('stylus').middleware(__dirname + '/www'));
 app.use(express.static(path.join(__dirname, 'www')));

--- a/modules/initsession.js
+++ b/modules/initsession.js
@@ -1,0 +1,34 @@
+var uuid = require('node-uuid');
+
+exports.initSession = function(req,res,next){
+
+    //Use virtual sessions based on origin. This grants us the same security as using tokens in each request, except we get it for free
+    if (req.headers.origin) {
+        if (req.session.virtualSessionByOrigin === undefined) {
+            req.session.virtualSessionByOrigin = {};
+        }
+        if (req.session.virtualSessionByOrigin[req.headers.origin] === undefined) {
+            req.session.virtualSessionByOrigin[req.headers.origin] = {};
+        }
+        req.virtualSession = req.session.virtualSessionByOrigin[req.headers.origin];
+    } else if (req.headers.host) { //if orgin isn't specified, this is not a cross-orgin XHR, so fallback to host
+        //not really better than a default session, but makes local dev debugging easier
+        if (req.session.virtualSessionByOrigin === undefined) {
+            req.session.virtualSessionByOrigin = {};
+        }
+        var thisOrigin = req.protocol + "://" + req.headers.host;
+        if (req.session.virtualSessionByOrigin[thisOrigin] === undefined) {
+            req.session.virtualSessionByOrigin[thisOrigin] = {};
+        }
+        req.virtualSession = req.session.virtualSessionByOrigin[thisOrigin];
+    } else { //if neither the orgin nor host header is set, use a default session
+        if (req.session.defaultVirtualSession === undefined) {
+            req.session.defaultVirtualSession = {};
+        }
+        req.virtualSession = req.session.defaultVirtualSession;
+    }
+    if (req.virtualSession.uuid === undefined) {
+        req.virtualSession.uuid = uuid.v4();
+    }
+    next();
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "db-migrate": ">=0.6.2",
     "cors": ">=2.1.0",
     "moment": ">=2.4.0",
-    "connect-pg": ">=1.1.5"
+    "connect-pg": ">=1.1.5",
+    "node-uuid": ">=1.4.1"
   },
   "devDependencies": {
     "mocha": ">=1.13.0",


### PR DESCRIPTION
Resolves #197

This middleware creates a virtual session based on origin to prevent security issues involved in allowing any origin to use the active session.

Also sets a UUID for the virtual session if one doesn't currently exist.

npm install is needed to install node-uuid
