### PR TITLE
Inline the answer labels for mobile

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -133,6 +133,10 @@ margin-bottom: 50px;
     display: inline-block !important; /* override a media query in purecss that makes buttons wrap on mobile */
 }
 
+.inline {
+    display: inline !important;
+}
+
 .answer {
     padding: 3px;
     width: 100%;

--- a/www/javascript/takesurvey.js
+++ b/www/javascript/takesurvey.js
@@ -214,6 +214,7 @@ function displaySurvey(results) {
                 // make the label (containing the value of the answer_
                 var answerLabel = $("<label></label>");
                 answerLabel.attr('for', 'answer-'+questionType+'-'+answerId);
+                answerLabel.attr('class', 'inline');
                 answerLabel.text(answerValue);
                 answerDiv.append(answerLabel);
 


### PR DESCRIPTION
This really annoyed me on the mobile version. Basically, when the page is small enough, the answer label would wrap to the next line, which is pretty annoying...
